### PR TITLE
Use a click-handler for slack to capture all click events and open in…

### DIFF
--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -26,6 +26,7 @@ module.exports = Ferdium => {
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
 
+  // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener('click', event => {
     const link = event.target.closest('a[href^="http"]');
     const button = event.target.closest('button[title^="http"]');

--- a/recipes/skype/webview.js
+++ b/recipes/skype/webview.js
@@ -30,6 +30,7 @@ module.exports = Ferdium => {
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
   Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
 
+  // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener('click', event => {
     const link = event.target.closest('a[href^="http"]');
     const button = event.target.closest('button[title^="http"]');

--- a/recipes/slack/package.json
+++ b/recipes/slack/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slack",
   "name": "Slack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.slack.com",

--- a/recipes/slack/webview.js
+++ b/recipes/slack/webview.js
@@ -75,4 +75,18 @@ module.exports = Ferdium => {
   }, 4000);
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+
+  // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
+  document.addEventListener('click', event => {
+    const link = event.target.closest('a[href^="http"]');
+    const button = event.target.closest('button[title^="http"]');
+
+    if (link || button) {
+      const url = link ? link.getAttribute('href') : button.getAttribute('title');
+
+      event.preventDefault();
+      event.stopPropagation();
+      window.location.href = url;
+    }
+  }, true);
 };

--- a/recipes/steamchat/webview.js
+++ b/recipes/steamchat/webview.js
@@ -30,6 +30,7 @@ module.exports = Ferdium => {
 
   Ferdium.loop(getMessages);
 
+  // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener('click', event => {
     const link = event.target.closest('a[href^="http"]');
 

--- a/recipes/zoom/webview.js
+++ b/recipes/zoom/webview.js
@@ -26,6 +26,7 @@ module.exports = Ferdium => {
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
 
+  // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener('click', event => {
     const link = event.target.closest('a[href^="http"]');
     const button = event.target.closest('button[title^="http"]');


### PR DESCRIPTION
… the same recipe webview

Should fix [#145](https://github.com/ferdium/ferdium-app/issues/145) for the time-being while we figure out a more sustainable solution that can scale across all services.