### PR TITLE
Fix open image in app or externally (instead of popup)

### DIFF
--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discordapp.com/login",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -4,8 +4,11 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
+function isImage(url) {
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
+}
+
 module.exports = (Ferdium, settings) => {
-  console.log('settings', settings);
   const getMessages = () => {
     let directCount = 0;
     const directCountPerServer = document.querySelectorAll(
@@ -34,14 +37,16 @@ module.exports = (Ferdium, settings) => {
 
     if (link || button) {
       const url = link ? link.getAttribute('href') : button.getAttribute('title');
+      
+      if (!isImage(url)) {
+        event.preventDefault();
+        event.stopPropagation();
 
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (settings.trapLinkClicks === true) {
-        window.location.href = url;
-      } else {
-        Ferdium.openNewWindow(url);
+        if (settings.trapLinkClicks === true) {
+          window.location.href = url;
+        } else {
+          Ferdium.openNewWindow(url);
+        }
       }
     }
   }, true);

--- a/recipes/zoom/package.json
+++ b/recipes/zoom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoom",
   "name": "Zoom",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://zoom.us/join",

--- a/recipes/zoom/webview.js
+++ b/recipes/zoom/webview.js
@@ -4,6 +4,10 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
+function isImage(url) {
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
+}
+
 module.exports = (Ferdium, settings) => {
   const getMessages = () => {
     let directCount = 0;
@@ -33,14 +37,16 @@ module.exports = (Ferdium, settings) => {
 
     if (link || button) {
       const url = link ? link.getAttribute('href') : button.getAttribute('title');
+      
+      if (!isImage(url)) {
+        event.preventDefault();
+        event.stopPropagation();
 
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (settings.trapLinkClicks === true) {
-        window.location.href = url;
-      } else {
-        Ferdium.openNewWindow(url);
+        if (settings.trapLinkClicks === true) {
+          window.location.href = url;
+        } else {
+          Ferdium.openNewWindow(url);
+        }
       }
     }
   }, true);


### PR DESCRIPTION
This attempts to fix https://github.com/ferdium/ferdium-app/issues/195.

Tested locally only with Discord but may also work with Zoom.

Skype and SteamChat services should also be included in this PR (in a similar approach) so that it fixes those too.

This is related to commit 4983daff125009865f8482388c37f69de8a610f7.