### PR TITLE
Add the native dark mode theme for Instagram

### DIFF
--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/direct/inbox",

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -17,20 +17,20 @@ module.exports = Ferdium => {
   Ferdium.handleDarkMode((isEnabled) => {
 
     var url = new URL(window.location.href);
-    var search_params = url.searchParams;
-    var isDarkModeParam = search_params.get('theme');
+    var searchParams = url.searchParams;
+    var isDarkModeParam = searchParams.get('theme');
     var changedParams = false;
 
     if (isEnabled) {
       isDarkModeParam ? null :
         (
-          search_params.set('theme', 'dark'),
+          searchParams.set('theme', 'dark'),
           changedParams = true
         );
     } else {
       isDarkModeParam ? 
         (
-          search_params.delete('theme', 'dark'),
+          searchParams.delete('theme', 'dark'),
           changedParams = true
         )
       : null;
@@ -38,7 +38,7 @@ module.exports = Ferdium => {
 
     changedParams ? 
       (
-        url.search = search_params.toString(),
+        url.search = searchParams.toString(),
         window.location.href = url.toString()
       )
     : null;

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -14,15 +14,13 @@ module.exports = Ferdium => {
 
   // https://github.com/ferdium/ferdium-recipes/blob/9d715597a600710c20f75412d3dcd8cdb7b3c39e/docs/frontend_api.md#usage-4
   // Helper that activates DarkReader and injects your darkmode.css at the same time
-  Ferdium.handleDarkMode((isEnabled, helpers) => {
-    if (isEnabled) {
-      helpers.enableDarkMode();
-      if (!helpers.isDarkModeStyleInjected()) {
-        helpers.injectDarkModeStyle();
-      }
-    } else {
-      helpers.disableDarkMode();
-      helpers.removeDarkModeStyle();
+  Ferdium.handleDarkMode((isEnabled) => {
+    const baseURL = window.location.href;
+    const nativeDarkTheme = '?theme=dark';
+    if (!baseURL.includes(nativeDarkTheme) && isEnabled) {
+      window.location.href = [...baseURL, nativeDarkTheme];
+    } else if (baseURL.includes(nativeDarkTheme) && !isEnabled) {
+      window.location.href = baseURL.replace(nativeDarkTheme,'');
     }
   });
 

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -15,13 +15,34 @@ module.exports = Ferdium => {
   // https://github.com/ferdium/ferdium-recipes/blob/9d715597a600710c20f75412d3dcd8cdb7b3c39e/docs/frontend_api.md#usage-4
   // Helper that activates DarkReader and injects your darkmode.css at the same time
   Ferdium.handleDarkMode((isEnabled) => {
-    const baseURL = window.location.href;
-    const nativeDarkTheme = '?theme=dark';
-    if (!baseURL.includes(nativeDarkTheme) && isEnabled) {
-      window.location.href = [...baseURL, nativeDarkTheme];
-    } else if (baseURL.includes(nativeDarkTheme) && !isEnabled) {
-      window.location.href = baseURL.replace(nativeDarkTheme,'');
+
+    var url = new URL(window.location.href);
+    var search_params = url.searchParams;
+    var isDarkModeParam = search_params.get('theme');
+    var changedParams = false;
+
+    if (isEnabled) {
+      isDarkModeParam ? null :
+        (
+          search_params.set('theme', 'dark'),
+          changedParams = true
+        );
+    } else {
+      isDarkModeParam ? 
+        (
+          search_params.delete('theme', 'dark'),
+          changedParams = true
+        )
+      : null;
     }
+
+    changedParams ? 
+      (
+        url.search = search_params.toString(),
+        window.location.href = url.toString()
+      )
+    : null;
+
   });
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));


### PR DESCRIPTION
This fixes https://github.com/ferdium/ferdium-recipes/issues/43 by adding the native handling of dark mode theme for Instagram. This disables the Ferdium injection of CSS for Instagram.