### PR TITLE
[Gmail] add support for priority inbox

### DIFF
--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -15,8 +15,8 @@ module.exports = Ferdium => {
   }
 
   const getMessages = () => {
-    let count = 0;
-    let count2 = 0;
+    let countImportant = 0;
+    let countNonImportant = 0;
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
     if (inboxLinks.length > 0) {
       let parentNode = inboxLinks[0].parentNode;
@@ -30,10 +30,10 @@ module.exports = Ferdium => {
               let counts = unreadCount
                 .split(':')
                 .map(s => Ferdium.safeParseInt(s.replace(/[^\p{N}]/gu, '')));
-              count = counts[0];
-              count2 = counts[1] - counts[0];
+              countImportant = counts[0];
+              countNonImportant = counts[1] - counts[0];
             } else {
-              count = Ferdium.safeParseInt(
+              countImportant = Ferdium.safeParseInt(
                 unreadCount.replace(/[^\p{N}]/gu, ''),
               );
             }
@@ -41,7 +41,7 @@ module.exports = Ferdium => {
         }
       }
     }
-    Ferdium.setBadge(count, count2);
+    Ferdium.setBadge(countImportant, countNonImportant);
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -15,8 +15,6 @@ module.exports = Ferdium => {
   }
 
   const getMessages = () => {
-    let count = 0;
-
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
     if (inboxLinks.length > 0) {
       let parentNode = inboxLinks[0].parentNode;
@@ -25,14 +23,18 @@ module.exports = Ferdium => {
         if (parentNodeOfParentNode) {
           const unreadCounts = parentNodeOfParentNode.querySelectorAll('.bsU');
           if (unreadCounts.length > 0) {
-            count = Ferdium.safeParseInt(unreadCounts[0].textContent.replace(/[^\p{N}]/gu, ''));
+			let unreadCount = unreadCounts[0].textContent
+			if (unreadCount.includes(":")){
+				let counts = unreadCount.split(":").map((s) => Ferdium.safeParseInt(s.replace(/[^\p{N}]/gu, '')))
+				Ferdium.setBadge(counts[0], counts[1] - counts[0]);
+			} else {
+				let count = Ferdium.safeParseInt(unreadCount.replace(/[^\p{N}]/gu, ''));
+				Ferdium.setBadge(count);
+			}
           }
         }
       }
     }
-
-    // set Ferdium badge
-    Ferdium.setBadge(count);
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -13,11 +13,10 @@ module.exports = Ferdium => {
     location.href =
       'https://accounts.google.com/AccountChooser?service=mail&continue=https://mail.google.com/mail/';
   }
-  
-  
+
   const getMessages = () => {
-	let count = 0;
-	let count2 = 0;
+    let count = 0;
+    let count2 = 0;
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
     if (inboxLinks.length > 0) {
       let parentNode = inboxLinks[0].parentNode;
@@ -26,19 +25,23 @@ module.exports = Ferdium => {
         if (parentNodeOfParentNode) {
           const unreadCounts = parentNodeOfParentNode.querySelectorAll('.bsU');
           if (unreadCounts.length > 0) {
-			let unreadCount = unreadCounts[0].textContent
-			if (unreadCount.includes(":")){
-				let counts = unreadCount.split(":").map((s) => Ferdium.safeParseInt(s.replace(/[^\p{N}]/gu, '')))
-				count = counts[0];
-				count2 = counts[1] - counts[0];
-			} else {
-				count = Ferdium.safeParseInt(unreadCount.replace(/[^\p{N}]/gu, ''));
-			}
+            let unreadCount = unreadCounts[0].textContent;
+            if (unreadCount.includes(':')) {
+              let counts = unreadCount
+                .split(':')
+                .map(s => Ferdium.safeParseInt(s.replace(/[^\p{N}]/gu, '')));
+              count = counts[0];
+              count2 = counts[1] - counts[0];
+            } else {
+              count = Ferdium.safeParseInt(
+                unreadCount.replace(/[^\p{N}]/gu, ''),
+              );
+            }
           }
         }
       }
     }
-	Ferdium.setBadge(count, count2);
+    Ferdium.setBadge(count, count2);
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -13,8 +13,11 @@ module.exports = Ferdium => {
     location.href =
       'https://accounts.google.com/AccountChooser?service=mail&continue=https://mail.google.com/mail/';
   }
-
+  
+  
   const getMessages = () => {
+	let count = 0;
+	let count2 = 0;
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
     if (inboxLinks.length > 0) {
       let parentNode = inboxLinks[0].parentNode;
@@ -26,15 +29,16 @@ module.exports = Ferdium => {
 			let unreadCount = unreadCounts[0].textContent
 			if (unreadCount.includes(":")){
 				let counts = unreadCount.split(":").map((s) => Ferdium.safeParseInt(s.replace(/[^\p{N}]/gu, '')))
-				Ferdium.setBadge(counts[0], counts[1] - counts[0]);
+				count = counts[0];
+				count2 = counts[1] - counts[0];
 			} else {
-				let count = Ferdium.safeParseInt(unreadCount.replace(/[^\p{N}]/gu, ''));
-				Ferdium.setBadge(count);
+				count = Ferdium.safeParseInt(unreadCount.replace(/[^\p{N}]/gu, ''));
 			}
           }
         }
       }
     }
+	Ferdium.setBadge(count, count2);
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
in gmail there are settings for different styles of inboxes. if this is set to "priority inbox" or "important first", the unread count consists of two numbers:

![image](https://user-images.githubusercontent.com/6146026/172362853-8bb8846a-f82a-4d06-8018-256cd2fcde01.png)

The first number is the number of unread "important" messages and the second number is the number of all unread messages.

Before Ferdium would read a wrong count and report this situation as 12 unread messages which is clearly wrong. I decided to change that so that the first number is reflected in the unread message count and the second number is used for the "indirect message" count