### PR TITLE
Remove whatsapp max width limit of 1600px

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/service.css
+++ b/recipes/whatsapp/service.css
@@ -11,3 +11,7 @@
 ._1Wk6A ._3YewW._31v_P._2Ptrm {
   display: none;
 }
+
+.app-wrapper-web ._1XkO3 {
+  max-width: none !important;
+}

--- a/recipes/whatsapp/service.css
+++ b/recipes/whatsapp/service.css
@@ -12,6 +12,7 @@
   display: none;
 }
 
+/* fix for blank spaces regarding view width on screens larger than 1080p */
 .app-wrapper-web ._1XkO3 {
   max-width: none !important;
 }


### PR DESCRIPTION
This PR fixes https://github.com/ferdium/ferdium-recipes/issues/45 and removes Whatsapp max width limited of 1600px.