### PR TITLE
Workaround for Whatsapp Web UI lag

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview-unsafe.js
+++ b/recipes/whatsapp/webview-unsafe.js
@@ -1,0 +1,42 @@
+const PUSHSTATE_NORMAL = 0;
+const PUSHSTATE_THROTTLE = 1;
+const PUSHSTATE_DISABLE = 2;
+
+const PUSHSTATE_THROTTLE_THRESHOLD = 1;
+
+window.shPushState = window.history.pushState;
+//window.pushStateBehavior = PUSHSTATE_NORMAL;
+window.pushStateBehavior = PUSHSTATE_THROTTLE;
+window.pushStateCount = 0;
+
+function pushStateThrottled() {
+	if (window.pushStateCount < PUSHSTATE_THROTTLE_THRESHOLD)
+	{
+		window.shPushState.apply(window.history, arguments);
+		window.pushStateCount++;
+
+		if (window.pushStateCount == PUSHSTATE_THROTTLE_THRESHOLD)
+			setTimeout(() => {
+				window.pushStateCount = 0;
+			},
+			5000);
+	}
+	else
+	{
+		console.log("Pushstate temporarily blocked!");
+	}
+}
+
+function pushStateOneShot() {
+	window.shPushState.apply(window.history, arguments);
+
+	window.history.pushState = function() {};
+
+	console.log("Pushstate Disabled!");
+}
+
+if (window.pushStateBehavior != PUSHSTATE_NORMAL)
+{
+	window.history.pushState =
+		window.pushStateBehavior == PUSHSTATE_THROTTLE ? pushStateThrottled : pushStateOneShot;
+}

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -36,6 +36,9 @@ module.exports = Ferdium => {
     Ferdium.setBadge(count, indirectCount);
   };
 
+  // inject webview hacking script
+  Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
+
   const getActiveDialogTitle = () => {
     const element = document.querySelector('header .emoji-texttt');
 


### PR DESCRIPTION
This is a workaround for Whatsapp Web UI constant lagging due to Whatsapp abusing history.pushState().

This MAY introduce other problems, but we have few conclusive reports on that so far.