### PR TITLE
yarn is no longer used - use pnpm instead

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_recipe.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_recipe.md
@@ -14,7 +14,7 @@ Service ID: [What ID does your recipe use?]
 ### Terminal output
 
 ```bash
-[Output of your terminal when you ran yarn package]
+[Output of your terminal when you ran pnpm package]
 ```
 
 ### Additional information


### PR DESCRIPTION
As in https://github.com/ferdium/ferdium-recipes/pull/98#issuecomment-1173237784 mentioned, yarn is no longer used - therefore here the updated PR template.