### PR TITLE
Fix in app URLs for discord

### DIFF
--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discordapp.com/login",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -33,8 +33,9 @@ module.exports = (Ferdium, settings) => {
 
     if (link || button) {
       const url = link ? link.getAttribute('href') : button.getAttribute('title');
-      
-      if (!Ferdium.isImage(url)) {
+      const stayInsideDiscord = url.includes('https://discordapp.com/channels/');
+
+      if (!Ferdium.isImage(url) && !stayInsideDiscord) {
         event.preventDefault();
         event.stopPropagation();
 


### PR DESCRIPTION
Since we implemented `trapLinkClicks` we broke some of discord functionalities (such as processing its internal links correctly - which now open in the browser instead).

This fixes that issue.

![Windows](https://user-images.githubusercontent.com/37463445/178021895-40ff3ec0-3457-4e59-9d1f-20928f44b25f.gif)