### PR TITLE
Use native darkmode for Whatsapp

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -54,6 +54,16 @@ module.exports = Ferdium => {
     Ferdium.releaseServiceWorkers();
   });
 
+  Ferdium.handleDarkMode((isEnabled) => {
+
+    if (isEnabled) {
+      document.body.classList.add('dark');
+    } else {
+      document.body.classList.remove('dark');
+    }
+
+  });
+
   Ferdium.loop(loopFunc);
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));


### PR DESCRIPTION
This can fix #90 by enabling the use of the native darkmode for Whatsapp.