### PR TITLE
Simplify GitHub badge count detection

### DIFF
--- a/recipes/github/webview.js
+++ b/recipes/github/webview.js
@@ -3,19 +3,12 @@ module.exports = Ferdium => {
     const directCountElement = document.querySelector(
       '.filter-list.js-notification-inboxes .count',
     );
-    let directCount = 0;
-    if (directCountElement) {
-      directCount = Ferdium.safeParseInt(directCountElement.textContent);
-    }
-
-    const indirectCountElement = document.querySelector(
-      '[class*="mail-status unread"]',
-    );
-    let indirectCount = 0;
-    if (indirectCountElement && indirectCountElement.textContent.trim().length > 0) {
-      indirectCount = 1;
-    }
-
+    const directCount = directCountElement
+      ? Ferdium.safeParseInt(directCountElement.textContent)
+      : 0;
+    const indirectCount = document.querySelector(
+      '[class*="mail-status unread"]:not([hidden])',
+    ) ? 1 : 0;
     Ferdium.setBadge(directCount, indirectCount);
   };
 


### PR DESCRIPTION
GitHub badge count detection was simplified to:

- avoid `if`s;
- improve selector for indirect count element so additional JavaScript content checking would not be necessary.