### PR TITLE
Error Handling on Office 365 landing page

### DIFF
--- a/recipes/office365-owa/package.json
+++ b/recipes/office365-owa/package.json
@@ -1,7 +1,7 @@
 {
   "id": "office365-owa",
   "name": "Office 365 Outlook",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "aliases": [
     "live.com",

--- a/recipes/office365-owa/webview.js
+++ b/recipes/office365-owa/webview.js
@@ -18,12 +18,10 @@ module.exports = (Ferdium, settings) => {
   const getMessages = () => {
     let directUnreadCount = 0;
     let indirectUnreadCount = 0;
-
     if (/\/owa/.test(location.pathname)) {
       // classic app
       directUnreadCount = Ferdium.safeParseInt(
-        document.querySelectorAll("span[title*='Inbox'] + div > span")[0]
-          .textContent,
+        document.querySelectorAll("span[title*='Inbox'] + div > span")[0]?.textContent
       );
     } else {
       // new app
@@ -37,6 +35,5 @@ module.exports = (Ferdium, settings) => {
 
     Ferdium.setBadge(directUnreadCount, indirectUnreadCount);
   };
-
   Ferdium.loop(getMessages);
 };


### PR DESCRIPTION
The error handling pretty much, wont try to `.textContent` if there is no `document.querySelectorAll("span[title*='Inbox'] + div > span")[0]`
It was throwing errors on the landing page because `/\/owa/` is true on that page