### PR TITLE
fix: messenger badge counter and hideInstallMessage

### DIFF
--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -1,7 +1,7 @@
 function hideInstallMessage() {
   const installMessage = document.querySelector('.usczdcwk');
-  if (installMessage.style.display != 'none') {
-    installMessage.style.display = 'none'
+  if (installMessage) {
+    installMessage.style.display = installMessage.style.display != 'none' ? 'none': installMessage.style.display;
   }
 }
 
@@ -27,9 +27,12 @@ module.exports = Ferdium => {
     Ferdium.setBadge(count);
   };
 
-  Ferdium.loop(getMessages);
+  const loopRoutine = () => {
+    getMessages()
+    hideInstallMessage()
+  };
 
-  Ferdium.loop(hideInstallMessage);
+  Ferdium.loop(loopRoutine);
 
   localStorage.setItem(
     '_cs_desktopNotifsEnabled',


### PR DESCRIPTION
Messenger notification badges weren't showing given the previous bad implementation of `Ferdium.loop` and `hideInstallMessage` (I'm to blame about this 😢)