### PR TITLE
ci: add lint and prettier to the pr checks

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       message:
-        description: 'Message for build'
+        description: "Message for build"
         required: true
 
 jobs:
@@ -31,8 +31,13 @@ jobs:
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install pnpm
         run: npm i -gf "pnpm@$(node -p 'require("./package.json").engines.pnpm')" && pnpm -v
       - name: Install node dependencies recursively
-        run: pnpm i && pnpm lint && pnpm reformat-files && pnpm package
+        run: pnpm i
+      - name: Check code style and formatting
+        if: ${{ github.event_name == 'pull_request' }}
+        run: pnpm lint && pnpm reformat-files
+      - name: Package recipes
+        run: pnpm package

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm i && pnpm lint && pnpm reformat-files && pnpm package
+pnpm i || exit 1
+pnpm lint:fix --quiet || exit 1
+pnpm reformat-files || exit 1
+pnpm package || exit 1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "pnpm dlx husky install",
     "package": "node scripts/package.js",
     "create": "node scripts/create.js",
-    "lint": "eslint . --fix --report-unused-disable-directives",
+    "lint": "eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\" --quiet",
+    "lint:fix": "npm run lint -- --fix",
     "reformat-files": "prettier --ignore-path .eslintignore --write --require-pragma \"**/*.{js,json,scss}\"",
     "contributors": "all-contributors"
   },

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -1,4 +1,9 @@
-
+function hideInstallMessage() {
+  const installMessage = document.querySelector('.usczdcwk');
+  if (installMessage) {
+    installMessage.style.display = installMessage.style.display != 'none' ? 'none': installMessage.style.display;
+  }
+}
 
 module.exports = Ferdium => {
   const getMessages = () => {
@@ -21,13 +26,6 @@ module.exports = Ferdium => {
 
     Ferdium.setBadge(count);
   };
-
-  function hideInstallMessage() {
-    const installMessage = document.querySelector('.usczdcwk');
-    if (installMessage) {
-      installMessage.style.display = installMessage.style.display != 'none' ? 'none': installMessage.style.display;
-    }
-  }
 
   const loopRoutine = () => {
     getMessages()

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -1,9 +1,4 @@
-function hideInstallMessage() {
-  const installMessage = document.querySelector('.usczdcwk');
-  if (installMessage) {
-    installMessage.style.display = installMessage.style.display != 'none' ? 'none': installMessage.style.display;
-  }
-}
+
 
 module.exports = Ferdium => {
   const getMessages = () => {
@@ -26,6 +21,13 @@ module.exports = Ferdium => {
 
     Ferdium.setBadge(count);
   };
+
+  function hideInstallMessage() {
+    const installMessage = document.querySelector('.usczdcwk');
+    if (installMessage) {
+      installMessage.style.display = installMessage.style.display != 'none' ? 'none': installMessage.style.display;
+    }
+  }
 
   const loopRoutine = () => {
     getMessages()


### PR DESCRIPTION
This PR adds a step in the CI build on PRs to check that `eslint` reports no errors, as requested in https://github.com/ferdium/ferdium-recipes/pull/95#issuecomment-1173158170.

The names of the `package.json`'s scripts have also been modified to match thoses in [ferdium-app's `package.json`](https://github.com/ferdium/ferdium-app/blob/develop/package.json).

This GitHub repository should enforce a passing CI to merge PRs.