### PR TITLE
fix: add warning to whatsapp theming

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/service.css
+++ b/recipes/whatsapp/service.css
@@ -16,3 +16,18 @@
 .app-wrapper-web ._1XkO3 {
   max-width: none !important;
 }
+
+/* Warning for trying to change theme on whatsapp */
+.ferdium-theme-message {
+  padding-top: 15px;
+  color: red;
+  line-height: 20px;
+}
+
+.ferdium-theme-title {
+  padding-top: 15px;
+  color: red;
+  line-height: 20px;
+  font-weight: bold;
+  text-align: center;
+}

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -4,6 +4,45 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
+function createElement(messageBody, idString) {
+  const messageText = document.createTextNode(messageBody);
+  const message = document.createElement("p");
+  message?.setAttribute("id", idString);
+  message?.setAttribute("class", idString);
+  message?.appendChild(messageText);
+
+  return message;
+}
+
+function addThemeMessage() {
+  const idString = 'ferdium-theme-message';
+  const idStringTitle = 'ferdium-theme-title';
+  const elementExists = document.querySelectorAll(`.${idString}`)[0] || document.querySelectorAll(`.${idStringTitle}`)[0] ? true : false;
+
+  if (!elementExists) {
+    const themePopupDiv = document.querySelectorAll("._2Nr6U")[0];
+
+    // Create Ferdium Warning title element
+    const messageTitleString = 'FERDIUM WARNING!';
+    const messageTitleElement = createElement(messageTitleString, idStringTitle);
+
+    // Create Ferdium Waring message element
+    const messageBody1 = 'To change your Whatsapp Theme, please use the native settings on Ferdium.';
+    const messageBody2 = 'For that, right-click on the Whatsapp Service and click on Enable/Disable Dark mode.';
+    const message1 = createElement(messageBody1, idString);
+    const message2 = createElement(messageBody2, idString);
+
+    // Add messages to Whatsapp Window
+    themePopupDiv?.prepend(message2)
+    themePopupDiv?.prepend(message1)
+    themePopupDiv?.prepend(messageTitleElement)
+
+    // Hide OK Button.
+    document.querySelectorAll("._20C5O")[1]?.setAttribute('style', 'display: none;');
+    document.querySelectorAll("._2Nr6U > form")[0]?.setAttribute('style', 'display: none;');
+  }
+}
+
 module.exports = Ferdium => {
   const getMessages = () => {
     let count = 0;
@@ -48,6 +87,7 @@ module.exports = Ferdium => {
   const loopFunc = () => {
     getMessages();
     getActiveDialogTitle();
+    addThemeMessage();
   };
 
   window.addEventListener('beforeunload', async () => {

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -26,7 +26,7 @@ function addThemeMessage() {
     const messageTitleString = 'FERDIUM WARNING!';
     const messageTitleElement = createElement(messageTitleString, idStringTitle);
 
-    // Create Ferdium Waring message element
+    // Create Ferdium Warning message element
     const messageBody1 = 'To change your Whatsapp Theme, please use the native settings on Ferdium.';
     const messageBody2 = 'For that, right-click on the Whatsapp Service and click on Enable/Disable Dark mode.';
     const message1 = createElement(messageBody1, idString);


### PR DESCRIPTION
This PR fixes an issue with Whatsapp Native Theming when users try to change it using the Whatsapp UI (and not through Ferdium). This issue is described in https://github.com/ferdium/ferdium-app/issues/490 and https://github.com/ferdium/ferdium-app/issues/535.

Now, users will have a popup window like shown in the image whenever they try to change the theme through the whatsapp UI.

![image](https://user-images.githubusercontent.com/37463445/182973620-041ffb9e-46a9-49bf-9d43-9d67c47051e0.png)