### PR TITLE
Pnpx removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
     "doc": "docs"
   },
   "engines": {
-    "pnpm": "7.6.0"
+    "pnpm": ">=7.6.0"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "pnpm dlx husky install",
     "package": "node scripts/package.js",
     "create": "node scripts/create.js",
-    "lint": "pnpx eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
-    "lint:fix": "pnpx eslint --fix \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "pnpm eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
+    "lint:fix": "pnpm eslint --fix \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
     "reformat-files": "prettier --ignore-path .eslintignore --write --require-pragma \"**/*.{js,json,scss}\"",
     "contributors": "all-contributors"
   },

--- a/recipes/onmail/icon.svg
+++ b/recipes/onmail/icon.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   clip-rule="evenodd"
+   fill-rule="evenodd"
+   stroke-linejoin="round"
+   stroke-miterlimit="2"
+   viewBox="0 0 1024 1024"
+   version="1.1"
+   id="svg70"
+   sodipodi:docname="icon.svg"
+   xml:space="preserve"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs74" /><sodipodi:namedview
+     id="namedview72"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="0.23046875"
+     inkscape:cx="512"
+     inkscape:cy="533.69492"
+     inkscape:window-width="1436"
+     inkscape:window-height="487"
+     inkscape:window-x="76"
+     inkscape:window-y="346"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg70" /><image
+     width="1019.7609"
+     height="1019.7609"
+     preserveAspectRatio="none"
+     xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABHNCSVQICAgIfAhkiAAABYBJREFU
+eJztnf112zYQwH/tBOwEQSeoM0HYCeoNim7gbsAN/DoBs0HaCeRMIGcCMRNInSD9g2StuqJ0d/gg
+ZOH3Hl4SBz4ceMAdPggQKpVKpVKpVCqVSqVSqVQqC3y3tgJC7qbkgA9HP2sW8h+A5+nvn4Fh+vfz
+Qv7KBRzwAHwC9sC3SGk/yXyYyqicoQE8sCWeAS6lLaNxlnraTeKAnnxGWOo5PTfeaxzrG+JUujnD
+NMAj6z/4S+mRG3Bl98QN0jlc2X2SJ7EyDePoZu0HbE2feEO95Q7Ysf5DDU27qS5JST0x9MT1xfPk
+7ivjZG9YyOem9I6XSWUMDsDvwMdI8rLiidMqHxn9eIhRm0lGT5wY5gN0WQVPuM9OGUzvgU2gjn1C
+/aLiCauky6irI2yw4TPqasJjq9gWaLNr+0KLfcnGZ9dWyB02/9ytoOsSHTajJB99aWnQD233FFgR
+bA1rT2HzFK0f3lJYBV7RoHdhm1U0PcE9b8sYMxajPKyi6RENuu59LcaY0RplddelWbW9NmPMaI3S
+hxQWsnTiGAO5hAPwnuWljhDaE2XF3jt36BrU+wQ6XKRH3mraiOXOSyCXRnVbxh4caySniZXZA7xT
+KPcYobyGcY5gXYfaEmcCp3HRLkJ5YqS9Y0d43Ii5qbUhrMdoBjFBsSSVUj6wHI1blKZ9oF5eUVaW
+QYxUoV1AGZY5gDb5AP12GcoQI52VhyiT690sq45eKH9rlC+mESoS0jtSuKlzybrvIu0lSd2WdOjX
+JZYfM1ln151QvjfIFiMd9jmDbMuKcazUG/R1CWWLkfh2q9/sBLJPpQ1jQ+kY45vVqM6gs+R57Axy
+xUgqZp0Iah7kntEAS66mRb9nbmnJUo+RhFZYuCVIamLHFnlrflDItcQSqd6tUm7Uwi0BshfKtqwY
+e6FsS2NyQrleKvB7ReGSJYfDlLS0wny/GeR/BP4U5v2glD0I8zmpQI1BJFiWnBtkCn80yofxbUMJ
+lnWuJ8PvLKIxyE8xCz5C+hD+CChjQNZL2oAyziHueRqDSHz3oJCnJXTD53MULf7PEFNYbJf11fA7
+TpDnySD3Nal28Cx1XiS2QSy4tRUoidgGeRdZ3jUQtc4agwyCPM6mxlXjBHnEQ3WNQaL6yhvjizRj
+bJfVRpZ3DUR9P1ljEOkoxRn0uFYaZNMB8QgvdgyB6+8lTpG3FeYbpAJT9BDtelAupIG1Vcj8RZgv
+2VuMkj2GnVJmJ5C5CVcdBOVo9L8TylNt2GmDusTSjjIP4oBc//5CnkaQR1Pmv2gNIl0P+lUpNxdP
+wnye5bcc2zP/d4q/hPkA29vvkp21A/AjMr/dctlvD8Q5rO/Qu9SBl6Ds0AX9A/CDsjw10t09n1oR
+IznvXOlyVEi6lattiblw5DFG1tNU0petu1wKKelIb5Cs1zp1QqX2lDtzl7peS4pxJkaF9B3fbxR0
+XPgEKeJJn7UGR2ha2OrHhc8Q87rBLq/q/0V7JLrUySKMw+4ddkNsKaR+HXKlS44nMx7d2ZQNkYf3
+MW6U2yF/0M/Az9hepsuJY+w1jnGL1k0/Hxg36p4ZZ/1F1qNF373dCnreFNrAWOpNQG8K7bnA0NOw
+lQs4bOfJ39SduKVhvVWu9paEeOzj+R3VMEnw2I0yGybldz084xxik0h+kXjCjHIcYx4IH5UtXaTc
+BsqNSuqrxu8YW2Gslj7fhfUM/D39eWpy1kxlz5O69ozMJ8bJ6s3gyPsZI0tqE9W9WBrK/ojLTcWS
+Y1rK/XRFm6zWhTPfDre2AWoveYWjvI+CtQnrezU4yjDM2h8EKI6Gcb6Re0TWUw1xEcfLp1djG2D+
+/KqnwEXNa/44cSv4vafpz/qB4kqlUqlUKpVKpVKpVCqV6+cfSUuL7zfW5gEAAAAASUVORK5CYII=
+"
+     id="image242"
+     x="4.5971947"
+     y="7.4123454" /></svg>

--- a/recipes/onmail/index.js
+++ b/recipes/onmail/index.js
@@ -1,0 +1,1 @@
+module.exports = Ferdium => Ferdium;

--- a/recipes/onmail/package.json
+++ b/recipes/onmail/package.json
@@ -1,0 +1,9 @@
+{
+  "id": "onmail",
+  "name": "onMail",
+  "version": "1.0.0",
+  "license": "MIT",
+  "config": {
+    "serviceURL": "https://mail.onmail.com"
+  }
+}

--- a/recipes/onmail/webview.js
+++ b/recipes/onmail/webview.js
@@ -1,0 +1,23 @@
+const _path = _interopRequireDefault(require('path'));
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+
+module.exports = Ferdium => {
+  // TODO: If your onMail service has unread messages, uncomment these lines to implement the logic for updating the badges
+  const getMessages = () => {
+    let countImportant = 0;
+    const inboxLinks = document.querySelectorAll('p.truncate');
+    for (const label of inboxLinks){
+      if (label.textContent) {
+        countImportant = label.nextSibling.textContent;
+        break;
+      }
+    }
+    Ferdium.setBadge(countImportant, 0);
+  };
+  Ferdium.loop(getMessages);
+
+  Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+};


### PR DESCRIPTION
removed pnpx from scripts, that is deprecated, `pnpm exec` is needed, `pnpm <command>` is sufficient if there are no path conflicts, line in this case  

- Allow pnpm from version 7.6.0 and up
- tested with 7.10, works fine
- tested with 7.11, works fine
 