### PR TITLE
Add Cinny recipe

### DIFF
--- a/recipes/cinny/icon.svg
+++ b/recipes/cinny/icon.svg
@@ -1,0 +1,14 @@
+<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 18 18" enable-background="new 0 0 18 18" xml:space="preserve">
+<defs>
+</defs>
+<g>
+	<g>
+		<circle fill="#FFFFFF" cx="9" cy="9" r="8.5"/>
+	</g>
+	<g>
+		<path d="M9,0C4,0,0,4,0,9c0,5,4,9,9,9c5,0,9-4,9-9C18,4,14,0,9,0z M1.2,10.8l3.5-2.3c0-0.1,0-0.2,0-0.3c0-1.8,1.3-3.2,3.1-3.4    c0.1,0,0.2,0,0.4,0c1.2,0,2.3,0.6,2.9,1.6c0.3-0.1,0.6-0.1,0.9-0.1c0.4,0,0.8,0,1.2,0.1c0.7,0.2,1.4,0.5,2,0.9    C14.6,7.1,14,7,13.3,7c-1.2,0-2.2,0.4-2.9,1.4c-0.7,0.9-1.1,2-1.1,3.2c0,1.5-0.4,2.9-1.3,4.2c-0.3,0.4-0.5,0.7-0.8,1    C4.2,16.1,1.9,13.8,1.2,10.8z"/>
+		<circle cx="9.5" cy="6.4" r="0.5"/>
+	</g>
+</g>
+<script xmlns=""/></svg>

--- a/recipes/cinny/index.js
+++ b/recipes/cinny/index.js
@@ -1,0 +1,1 @@
+module.exports = Ferdium => Ferdium;

--- a/recipes/cinny/package.json
+++ b/recipes/cinny/package.json
@@ -1,0 +1,17 @@
+{
+  "id": "cinny",
+  "name": "Cinny",
+  "version": "1.0.0",
+  "license": "MIT",
+  "aliases": [
+    "Matrix"
+  ],
+  "config": {
+    "serviceURL": "https://app.cinny.in/",
+    "hasCustomUrl": true,
+    "message": "Cinny's default URL is https://app.cinny.in/",
+    "hasNotificationSound": true,
+    "hasDirectMessages": true,
+    "hasIndirectMessages": true
+  }
+}

--- a/recipes/cinny/webview.js
+++ b/recipes/cinny/webview.js
@@ -1,0 +1,22 @@
+module.exports = Ferdium => {
+  function getMessages() {
+    // Number of messages from rooms which has "All Messages" notifications enabled or when mentionned in a room with "Mentions & Keyword" notifications level.
+    let directCount = 0;
+    // Number of messages for rooms which has "Mentions & Keyword" notifications level set which does not directly mention you.
+    let indirectCount = 0;
+
+    // Retrieves notification badges
+    const badges = document.querySelectorAll('.sidebar .notification-badge');
+    for (const badge of badges) {
+      if (badge.childNodes.length === 0) {
+        indirectCount++;
+      } else {
+        directCount += Ferdium.safeParseInt(badge.childNodes[0].textContent);
+      }
+    }
+
+    // Set Ferdium badge
+    Ferdium.setBadge(directCount, indirectCount);
+  }
+  Ferdium.loop(getMessages);
+};


### PR DESCRIPTION
## Adding new recipe

Service: [Cinny](https://cinny.in/)
URL: https://app.cinny.in/
Service ID: `cinny`

### Terminal output

```bash

> ferdium-recipes@1.0.1 package /home/orax/tmp/ferdium-recipes
> node scripts/package.js

✅ Successfully packaged and added 250 recipes (0 unsuccessful recipes)
```

### Additional information

<!-- Please also accept the following checkboxes -->

- [x] I am the original creator of this package
- [x] I have run the `pnpm lint:fix && pnpm reformat-files && pnpm package` and verified that there are no validation errors reported for this package
- [x] My recipe has been tested to work inside Ferdium

<!-- Here you can write anything else you want to tell us. -->

Cinny is a Matrix client, an alternative to [Element](https://element.io/), which has been published alongside it on the official [matrix.org clients page](https://matrix.org/clients/). I feel like including alternative clients for the Matrix ecosystem in Ferdium can only be a good thing !