### PR TITLE
fix: whatsapp message count selector

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -16,7 +16,7 @@ module.exports = Ferdium => {
       return;
     }
 
-    const unreadSpans = parentChatElem.querySelectorAll('span[aria-label]');
+    const unreadSpans = parentChatElem.querySelectorAll('div[role="gridcell"] > span > div > span[aria-label]');
     for (const unreadElem of unreadSpans) {
       const countValue = Ferdium.safeParseInt(unreadElem.textContent);
       if (countValue > 0) {


### PR DESCRIPTION
Fixes #230.

WhatsApp seems to have added `aria-label` to all components in each conversation, when they only used it for message counts previously.
The new selector only select the message count for each conversation, and so the count is correct as previously.