### PR TITLE
Fixed bug #230: whatsapp count

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -8,10 +8,11 @@ module.exports = Ferdium => {
   const getMessages = () => {
   
     // first find the css selector for the unread count text
+    var unreadSelector;
     [...document.styleSheets].every(sheet => {
-      matchedRule = Array.from(sheet.cssRules).find(
+      const matchedRule = [...sheet.cssRules].find(
           rule => (
-            rule.type === CSSRule.STYLE_RULE && 
+            rule.constructor.name === "CSSStyleRule" && 
             rule.style['color'] === 'var(--unread-marker-text)'
           )
       );
@@ -21,9 +22,8 @@ module.exports = Ferdium => {
     let count = 0;
     let indirectCount = 0;
 
-    [...document.querySelectorAll(unreadSelector)].forEach(
-      unreadElem => {
-        const countValue = Ferdium.safeParseInt(unreadElem.innerText);
+    for (const unreadElem of document.querySelectorAll(unreadSelector)) {
+        const countValue = Ferdium.safeParseInt(unreadElem.textContent);
         if (
           !unreadElem.parentNode.previousSibling ||
           unreadElem.parentNode.previousSibling.querySelector(
@@ -35,7 +35,6 @@ module.exports = Ferdium => {
           indirectCount += countValue;
         }
       }
-    );
           
     Ferdium.setBadge(count, indirectCount);
   };

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -26,7 +26,7 @@ module.exports = Ferdium => {
         const countValue = Ferdium.safeParseInt(unreadElem.textContent);
         if (
           !unreadElem.parentNode.previousSibling ||
-          unreadElem.parentNode.previousSibling.querySelector(
+          unreadElem.parentNode.parentNode.querySelector(
             '[data-icon=muted]'
           ) === null
         ) {

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -6,33 +6,37 @@ function _interopRequireDefault(obj) {
 
 module.exports = Ferdium => {
   const getMessages = () => {
+  
+    // first find the css selector for the unread count text
+    [...document.styleSheets].every(sheet => {
+      matchedRule = Array.from(sheet.cssRules).find(
+          rule => (
+            rule.type === CSSRule.STYLE_RULE && 
+            rule.style['color'] === 'var(--unread-marker-text)'
+          )
+      );
+      return (unreadSelector = matchedRule !== undefined ? matchedRule.selectorText : '') === '';
+    });
+
     let count = 0;
     let indirectCount = 0;
 
-    const parentChatElem = [
-      ...document.querySelectorAll('div[aria-label]'),
-    ].sort((a, b) => (a.offsetHeight < b.offsetHeight ? 1 : -1))[0];
-    if (!parentChatElem) {
-      return;
-    }
-
-    const unreadSpans = parentChatElem.querySelectorAll('span[aria-label]');
-    for (const unreadElem of unreadSpans) {
-      const countValue = Ferdium.safeParseInt(unreadElem.textContent);
-      if (countValue > 0) {
+    [...document.querySelectorAll(unreadSelector)].forEach(
+      unreadElem => {
+        const countValue = Ferdium.safeParseInt(unreadElem.innerText);
         if (
           !unreadElem.parentNode.previousSibling ||
-          unreadElem.parentNode.previousSibling.querySelectorAll(
-            '[data-icon=muted]',
-          ).length === 0
+          unreadElem.parentNode.previousSibling.querySelector(
+            '[data-icon=muted]'
+          ) === null
         ) {
           count += countValue;
         } else {
           indirectCount += countValue;
         }
       }
-    }
-
+    );
+          
     Ferdium.setBadge(count, indirectCount);
   };
 


### PR DESCRIPTION
I tried to fix bug #230 by first finding out the proper CSS selector (here: class name) for the span with the unread count texts and then add the counts in its content.
Hope that this method is more stable as it relies on a variable name for the color of unread count badge.
Could not figure out what the previously contained height comparison is used here, so I left it out, but even if it is necessary, the first part of my code (to find out the CSS class name) could still be useful, as the class names are mini- and uglyfied.