### PR TITLE
Get Element messages count from the spaces navbar

### DIFF
--- a/recipes/element/package.json
+++ b/recipes/element/package.json
@@ -1,7 +1,7 @@
 {
   "id": "element",
   "name": "Element",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "aliases": [
     "Riot.im",

--- a/recipes/element/webview.js
+++ b/recipes/element/webview.js
@@ -1,25 +1,14 @@
 module.exports = Ferdium => {
   function getMessages() {
-    const badges = document.querySelectorAll('.mx_RoomList .mx_RoomSublist_tiles .mx_NotificationBadge');
-    // Number of messages from rooms which has "All Messages" notifications enabled.
-    // Always incremented for private rooms by default, incremented for group chats if
-    // "All Messages" is selected for them in notifications settings.
     let directCount = 0;
-    // Number of messages for rooms which has "Only Highlights" notifications level set.
-    // Appears in rooms list with dots on right.
-    let indirectCount = 0;
-    
-    for (const badge of badges) {
-      if (badge.classList.contains('mx_NotificationBadge_dot')) {
-        indirectCount++;
-      } else {
-        directCount += Ferdium.safeParseInt(badge.childNodes[0].textContent);
-      }
-    }
-
-    // set Ferdium badge
+    const spacesBar = document.querySelector('.mx_SpaceTreeLevel');
+    spacesBar.querySelectorAll('.mx_NotificationBadge_count').forEach((badge) => {
+      directCount += Ferdium.safeParseInt(badge.textContent);
+    });
+    const indirectCount = spacesBar.querySelectorAll('.mx_NotificationBadge_dot')
+      .length;
     Ferdium.setBadge(directCount, indirectCount);
   }
+
   Ferdium.loop(getMessages);
 };
-


### PR DESCRIPTION
Element recipe was updated to get direct messages count from the spaces navigation bar as previously it was retrieved only from the active space resulting in situations when there are new messages in Element but there is no indicator if the currently selected Element space does not have unread notifications.

I am not completely sure if these changes do not break something, but from my side everything seemed fine.
Additionally, I could not find any setting in Element that would disable spaces, so I am considering these changes quite safe.