### PR TITLE
fix #265: change to the service url for standardnotes

### DIFF
--- a/recipes/standardnotes/package.json
+++ b/recipes/standardnotes/package.json
@@ -1,10 +1,10 @@
 {
   "id": "standardnotes",
   "name": "StandardNotes",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "https://github.com/vantezzen/franz-recipe-standardnotes",
   "config": {
-    "serviceURL": "https://app.standardnotes.org/"
+    "serviceURL": "https://app.standardnotes.com/"
   }
 }


### PR DESCRIPTION
changes the serviceUrl as per the screenshot from #265 