### PR TITLE
Fix unread notifications count for Element

### DIFF
--- a/recipes/element/package.json
+++ b/recipes/element/package.json
@@ -1,7 +1,7 @@
 {
   "id": "element",
   "name": "Element",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "aliases": [
     "Riot.im",

--- a/recipes/element/webview.js
+++ b/recipes/element/webview.js
@@ -2,9 +2,20 @@ module.exports = Ferdium => {
   function getMessages() {
     let directCount = 0;
     const spacesBar = document.querySelector('.mx_SpaceTreeLevel');
-    for (const badge of spacesBar.querySelectorAll('.mx_NotificationBadge_count')) {
-      directCount += Ferdium.safeParseInt(badge.textContent);
+
+    for (const badge of spacesBar.querySelectorAll(
+      '.mx_SpaceItem:not(.mx_SpaceItem_narrow):first-of-type .mx_NotificationBadge_count, '
+        + '.mx_SpaceItem_narrow .mx_NotificationBadge_count'
+    )) {
+      const badgeContent = badge.textContent.toLowerCase();
+      directCount += badgeContent.endsWith('k')
+        ? Number.parseFloat(badgeContent) * 1000 + Number.parseInt(
+          '5'.padEnd(Number.parseInt(badgeContent, 10).toString().length + 1, 0),
+          10
+        )
+        : Ferdium.safeParseInt(badgeContent)
     }
+
     const indirectCount = spacesBar.querySelectorAll('.mx_NotificationBadge_dot')
       .length;
     Ferdium.setBadge(directCount, indirectCount);


### PR DESCRIPTION
The following fixes were made:

- take only the space "Home" and ignore other built-in spaces (if they are enabled) as count in "Home" badge includes notifications from other built-in spaces as well;
- calculate approximate count from composite numbers (1.2K, 2.3K).

This is one of the two suggested solutions for #268.
Personally I prefer #272 over this pull request.

Before:
![Element before](https://user-images.githubusercontent.com/9976861/209783182-858efeb8-be1e-4009-bda0-06bbae6f8e35.png)

After:
![Element after - guessed count](https://user-images.githubusercontent.com/9976861/209783231-3d187ef3-762f-434c-93f8-462e8203baf6.png)

If this pull request is accepted, #272 should be closed.