### PR TITLE
Use unread rooms count like Element app does

### DIFF
--- a/recipes/element/package.json
+++ b/recipes/element/package.json
@@ -1,7 +1,7 @@
 {
   "id": "element",
   "name": "Element",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "aliases": [
     "Riot.im",

--- a/recipes/element/webview.js
+++ b/recipes/element/webview.js
@@ -1,11 +1,10 @@
 module.exports = Ferdium => {
   function getMessages() {
-    let directCount = 0;
-    const spacesBar = document.querySelector('.mx_SpaceTreeLevel');
-    for (const badge of spacesBar.querySelectorAll('.mx_NotificationBadge_count')) {
-      directCount += Ferdium.safeParseInt(badge.textContent);
-    }
-    const indirectCount = spacesBar.querySelectorAll('.mx_NotificationBadge_dot')
+    const matches = document.querySelector('title').textContent
+      .match('(?<=\\[)\\d+(?=])');
+    const directCount = Ferdium.safeParseInt(matches !== null ? matches[0] : 0);
+    const indirectCount = document.querySelector('.mx_SpaceTreeLevel')
+      .querySelectorAll('.mx_NotificationBadge_dot')
       .length;
     Ferdium.setBadge(directCount, indirectCount);
   }


### PR DESCRIPTION
This change uses unread rooms instead of messages count like Element (web)app does
Unread rooms count is extracted from the `title` tag.

This is one of the two suggested solutions for #268.
Personally I prefer this over #271.

Before:
![Element before](https://user-images.githubusercontent.com/9976861/209783296-b8867b4c-8095-412c-b73c-0a4a05f398d3.png)

After:
![Element after - unread rooms count](https://user-images.githubusercontent.com/9976861/209783312-ac2e9847-f816-441b-a802-1baf8d2a5638.png)

If this pull request is accepted, #271 should be closed.