### PR TITLE
fix: add mastodon hosted option and remove teamId

### DIFF
--- a/recipes/mastodon/package.json
+++ b/recipes/mastodon/package.json
@@ -1,11 +1,12 @@
 {
   "name": "Mastodon",
   "id": "mastodon",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
+    "serviceURL": "https://mastodon.social",
     "hasNotificationSound": true,
-    "hasTeamId": true,
+    "hasHostedOption": true,
     "hasCustomUrl": true
   }
 }


### PR DESCRIPTION
Fixes mastodon recipe which add teamId assigned incorrectly. It should use the hosted option instead (as per discussed with @vraravam [here](https://discord.com/channels/963836780778512454/963841911376982046/1065200823803584564))

| Before | After |
|-- |-- |
| ![image](https://user-images.githubusercontent.com/37463445/213205441-d83a534b-703e-4b00-96ba-1370fd7bc467.png) | ![image](https://user-images.githubusercontent.com/37463445/213205492-4ad6c99a-0068-4329-a707-d1e1164a69bb.png)