### PR TITLE
Fix unread notifications count for yahoo-mail

### DIFF
--- a/recipes/yahoo-mail/package.json
+++ b/recipes/yahoo-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "yahoo-mail",
   "name": "Yahoo Mail",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.yahoo.com",

--- a/recipes/yahoo-mail/webview.js
+++ b/recipes/yahoo-mail/webview.js
@@ -1,6 +1,6 @@
 module.exports = (Ferdium) => {
   const getMessages = () => {
-    const count = document.querySelector('a[data-test-folder-name="Inbox"]').getAttribute('data-test-unread-count');
+    const count = document.querySelector('a[data-test-folder-name="Inbox"] span[data-test-id="displayed-count"]').textContent;
     Ferdium.setBadge(count);
   };
 


### PR DESCRIPTION
`data-test-unread-count` attribute does not exist anymore. Using text content of notification `span` element.