### PR TITLE
Add custom URL option on Pixelfed

### DIFF
--- a/recipes/pixelfed/package.json
+++ b/recipes/pixelfed/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pixelfed",
   "name": "Pixelfed",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pixelfed.social",

--- a/recipes/pixelfed/package.json
+++ b/recipes/pixelfed/package.json
@@ -4,6 +4,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://pixelfed.social"
+    "serviceURL": "https://pixelfed.social",
+    "hasHostedOption": true,
+    "hasCustomUrl": true
   }
 }


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

I added the option to enter a custom URL on the Pixelfed service, in order to make it possible to use an hosted instance.

Closes https://github.com/ferdium/ferdium-app/issues/963
