### PR TITLE
Fix URL in Amazon WorkMail

### DIFF
--- a/recipes/amazon-work-mail/package.json
+++ b/recipes/amazon-work-mail/package.json
@@ -1,10 +1,10 @@
 {
   "id": "amazon-work-mail",
   "name": "Amazon WorkMail",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://{teamID}.awsapps.com/mail",
+    "serviceURL": "https://{teamId}.awsapps.com/mail",
     "hasTeamId": true
   }
 }

--- a/recipes/amazon-work-mail/package.json
+++ b/recipes/amazon-work-mail/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.awsapps.com/mail",
-    "hasTeamId": true
+    "hasTeamId": true,
+    "urlInputSuffix": ".awsapps.com/mail"
   }
 }


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

I fixed the URL of the Amazon WorkMail service. The variable name in the URL should be `teamId` and not `teamID`. Fixes https://github.com/ferdium/ferdium-app/issues/1134.