### PR TITLE
Do not use pnpx in lint and lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prepare": "pnpm dlx husky install",
     "package": "node scripts/package.js",
     "create": "node scripts/create.js",
-    "lint": "pnpx eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
-    "lint:fix": "pnpx eslint --fix \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "pnpm dlx eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
+    "lint:fix": "pnpm dlx eslint --fix \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
     "reformat-files": "prettier --ignore-path .eslintignore --write --require-pragma \"**/*.{js,json,scss}\"",
     "contributors": "all-contributors"
   },


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

Changed the `pnpm lint` and `pnpm lint:fix` subcommands to use `pnpm dlx` instead of `pnpx` as the later is deprecated.

This is a problem for new contributors who try to follow the instructions to run `pnpm lint:fix` before opening a PR, only to find it doesn't work with their version of `pnpm`.