### PR TITLE
feat(tt-rss): Optionally limit notifications to a Category.

### DIFF
--- a/recipes/tt-rss/README.md
+++ b/recipes/tt-rss/README.md
@@ -1,3 +1,39 @@
 # Tiny Tiny RSS for Ferdium
 
-Support for [Tiny Tiny RSS](https://tt-rss.org/)
+Interact with [Tiny Tiny RSS](https://tt-rss.org/) inside of Ferdium!
+
+## Usage
+
+1. Search for "RSS" in Ferdium's **Available Services**
+2. Enter the URL of your Tiny Tiny RSS server
+3. Save the service and log in!
+
+## Configuration
+
+### `ferdiumNotificationLabel`
+
+You can limit notifications from Tiny Tiny RSS to new articles in a specific
+Category using the custom `ferdiumNotificationLabel` query parameter as part of
+your server URL.
+
+```
+https://ttrss.example.com/tt-rss/?ferdiumNotificationLabel=CATEGORY_NAME
+```
+
+For example, if I wanted to only see notifications from a Category titled
+`Software - Updates`, I would use one of the following query parameters:
+
+```
+?ferdiumNotificationLabel=Software - Updates
+```
+**OR**
+```
+?ferdiumNotificationLabel=Software%20-%20Updates
+```
+
+The second option is the better/safer approach to take, but the first also works
+because Ferdium will escape the spaces for you (at least as of version 6.2.7).
+
+NOTE: When using the `ferdiumNotificationLabel` configuration, all other unread
+articles in other categories are reported as [**indirect**
+messages](https://github.com/ferdium/ferdium-recipes/blob/main/docs/frontend_api.md#setbadgedirectmessages-indirectmessages).

--- a/recipes/tt-rss/package.json
+++ b/recipes/tt-rss/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tt-rss",
   "name": "Tiny Tiny RSS",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/tt-rss/webview.js
+++ b/recipes/tt-rss/webview.js
@@ -1,16 +1,41 @@
 "use strict";
 
 module.exports = Ferdium => {
+  const _notificationCategory = new URL(window.location.href).searchParams.get("ferdiumNotificationCategory");
+  
   const getMessages = function getMessages() {
-    // Initialize empty vars
-    var unread = 0;
-    var match = [];
-    // Extract the number from the title
-    match = document.title.match(/^\((\d+)\) Tiny Tiny RSS$/);
-    // Some logic to handle the match groups
-    unread = match != null && match.length > 0 ? match[1] : 0;
-    // Set unread msgs badge
-    Ferdium.setBadge(Number.parseInt(unread, 10));
+    if (_notificationCategory) {
+      countMessagesUnderCategory(_notificationCategory);
+    } else {
+      countMessages();
+    }
+  };
+
+  const countMessagesUnderCategory = (notificationCategory) => {
+    var elements = document.querySelectorAll(".dijitTreeIsRoot")
+    var directMessages = 0;
+    var indirectMessages = 0;
+    for (var element of elements) {
+      var label = element.querySelectorAll(".dijitTreeLabel")[0];
+      var unreadNode = element.querySelectorAll(".unread")[0];
+      var unreadAmount = Ferdium.safeParseInt(unreadNode.textContent);
+      if (label.textContent === notificationCategory) {
+        directMessages += unreadAmount;
+      } else {
+        indirectMessages += unreadAmount;
+      }
+    }
+    Ferdium.setBadge(directMessages, indirectMessages);
+  };
+
+  const _countMessagesFromTitle = () => {
+    var match = document.title.match(/^\((\d+)\) Tiny Tiny RSS$/);
+    var count = match != null && match.length > 0 ? match[1] : 0;
+    return Ferdium.safeParseInt(count);
+  }
+
+  const countMessages = () => {
+    Ferdium.setBadge(_countMessagesFromTitle());
   };
 
   const loopFunc = () => {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

As described in the updated README for tt-rss, users can now choose to limit notifications to only new articles published under a Category of their choosing. Articles published in other Categories are then considered "indirect" messages.

This feature is made available via parsing a custom URL parameter from the Service URL. Preferrably Ferdium would enable recipies to request custom fields from users, but for now this workaround accomplishes the task.