### PR TITLE
fix(github): Include "new notifications" in direct total

### DIFF
--- a/recipes/github/package.json
+++ b/recipes/github/package.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "GitHub",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://github.com/notifications",

--- a/recipes/github/webview.js
+++ b/recipes/github/webview.js
@@ -1,11 +1,22 @@
 module.exports = Ferdium => {
+  const _parseNewCount = (text) => {
+    const match = text.match(/\d+/);
+    return match ? Ferdium.safeParseInt(match[0]) : 0;
+  };
+
   const getMessages = () => {
     const directCountElement = document.querySelector(
       '.filter-list.js-notification-inboxes .count',
     );
-    const directCount = directCountElement
+    let directCount = directCountElement
       ? Ferdium.safeParseInt(directCountElement.textContent)
       : 0;
+    
+    const newCountElement = document.querySelector('a.h6[href="/notifications?query="]');
+    const newCount = newCountElement ?
+      _parseNewCount(newCountElement.textContent) : 0;
+    directCount += newCount;
+
     const indirectCount = document.querySelector(
       '[class*="mail-status unread"]:not([hidden])',
     ) ? 1 : 0;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
GitHub's notification page no longer updates the notification count when notifications arrive. Instead, it displays a small message saying "COUNT new notifications".

This PR includes that COUNT in the number of direct messages reported to Ferdium.

For example, with this update, my GitHub icon in Ferdium shows 7 direct messages, 4 of which come from the inbox, and 3 of which come from the "new notifications" banner. Prior to this commit, the GitHub icon would only show the 4 direct messages from the inbox.

![image](https://github.com/ferdium/ferdium-recipes/assets/47901316/580622fa-21da-4e1d-8cf5-8a28933a93b0)


