### PR TITLE
Fix Instagram messages count

### DIFF
--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "config": {
       "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram-direct-messages/webview.js
+++ b/recipes/instagram-direct-messages/webview.js
@@ -15,7 +15,7 @@ setInterval(() => {
 module.exports = (Ferdium) => {
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"]');
-    Ferdium.setBadge(element ? Ferdium.safeParseInt(element.textContent.match(/\d+/)[0]) : 0);
+    Ferdium.setBadge(element.textContent ? Ferdium.safeParseInt(element.textContent) : 0);
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/direct/inbox",

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -7,7 +7,7 @@ function _interopRequireDefault(obj) {
 module.exports = Ferdium => {
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"]');
-    Ferdium.setBadge(element ? Ferdium.safeParseInt(element.textContent) : 0);
+    Ferdium.setBadge(element.textContent ? Ferdium.safeParseInt(element.textContent) : 0);
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

The messages count on Instagram wasn’t updated after having read the last unread message because `element.textContent` was `''` instead of `0`. So I updated the code to set the count to 0 if `element.textContent` is an empty string.