### PR TITLE
Open Telegram links within Ferdium

### DIFF
--- a/recipes/telegram/package.json
+++ b/recipes/telegram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "telegram",
   "name": "Telegram",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.telegram.org",

--- a/recipes/telegram/webview.js
+++ b/recipes/telegram/webview.js
@@ -95,7 +95,11 @@ module.exports = (Ferdium, settings) => {
         event.preventDefault();
         event.stopPropagation();
 
-        if (settings.trapLinkClicks === true) {
+        if (
+          settings.trapLinkClicks === true
+          || url.includes('t.me')
+          || url.includes('web.telegram.org')
+        ) {
           window.location.href = url;
         } else {
           Ferdium.openNewWindow(url);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

I modified Telegram’s recipe so that links which contain `t.me` or `web.telegram.org` open within Ferdium no matter what the setting for all links is and despite their `target="_blank"`.

Fixes https://github.com/ferdium/ferdium-app/issues/1275