### PR TITLE
ci: modernize github actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,28 +14,27 @@ on:
   workflow_dispatch:
     inputs:
       message:
-        description: "Message for build"
+        description: 'Message for build'
         required: true
 
 jobs:
   build:
     name: Ferdium Recipes Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print latest commit
         run: echo ${{ github.sha }}
-      - name: Set env vars
-        run: echo "PNPM_CACHE=$HOME/.pnpm-store" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
-      - name: Install pnpm
-        run: npm i -gf "pnpm@$(node -p 'require("./package.json").engines.pnpm')" && pnpm -v
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - name: Install node dependencies recursively
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@v2.8.3
         with:
           command: pnpm i
           timeout_minutes: 15

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   check:
     name: Check Recipe Version Bump
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Fetch main branch
         run: git fetch origin main --depth 1
-      - uses: tj-actions/changed-files@v36
+      - uses: tj-actions/changed-files@v37
         id: changed-files
       - name: Checking recipe version bump
         uses: ./.github/workflows/check-recipe-version-bump

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pnpm": "8.6.2"
   },
   "engine-strict": true,
+  "packageManager": "pnpm@8.6.2",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "is-ci || husky install",


### PR DESCRIPTION

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- use `ubuntu-22.04` runner instead of `ubuntu-20.04`
- use `pnpm/action-setup` instead of handling `pnpm install` manually
- upgrade `tj-actions/changed-files` from v36 to v37
- define `packageManager` config option in `package.json` which is read by `pnpm/action-setup`
