### PR TITLE
Fix telegram deeplink by adding empty onload

### DIFF
--- a/recipes/telegram/package.json
+++ b/recipes/telegram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "telegram",
   "name": "Telegram",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.telegram.org",

--- a/recipes/telegram/webview.js
+++ b/recipes/telegram/webview.js
@@ -85,6 +85,9 @@ module.exports = (Ferdium, settings) => {
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
 
+  // This is a hack to get the telegram web app to open links in Ferdium (otherwise it asks to deeplink and open with any tg:// protocol handler)
+  window.onload(() => {});
+
   // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener(
     'click',


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
This is the weirdest fix I've ever done, but it seems like if we "override" somehow the `window.onload()` we fix the issue described on https://github.com/ferdium/ferdium-app/issues/1275 (came upon this while trying to solve the issue). Basically, the problem is that whenever we click a button we push a new route that has a script to check for the window.protoUrl and then if it starts with `t.me` tries to navigate to the `tg://` deeplink. Seems like by introducing the `window.onload` method we somehow fix the behaviour, preventing it from navigating to deeplink.

Would be good if someone also tested this PR before merging as this fix is kind of weird.
