### PR TITLE
Fix Whatsapp recipe unread counts for muted conversations

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -18,7 +18,7 @@ module.exports = Ferdium => {
       query.onsuccess = event => {
         for (const chat of event.target.result) {
           if (chat.unreadCount > 0) {
-            if (chat.muteExpiration > 0 || chat.isAutoMuted) {
+            if (chat.muteExpiration != 0 || chat.isAutoMuted) {
               unreadMutedCount += chat.unreadCount;
             } else {
               unreadCount += chat.unreadCount;


### PR DESCRIPTION
…ions.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

This is a bugfix for [issue #1303](https://github.com/ferdium/ferdium-app/issues/1303). Unread counts/badges were erroneously incrementing for Whatsapp conversations that were marked as muted. When mute option "Always" is chosen in Whatsapp Web, the value of `chat.muteExpiration` in webview.js is set to `-1`, however the conditional that governs incrementing of unread counts expected a positive non-zero value in this variable to indicate a muted conversation. Chaging the comparison from `> 0` to `!= 0` solved the issue.