### PR TITLE
Ensure that links are opened according to the user's preference

### DIFF
--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/direct/inbox",

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/direct/inbox",

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.2",
+  "version": "2.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/direct/inbox",

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -4,12 +4,43 @@ function _interopRequireDefault(obj) {
 
 const _path = _interopRequireDefault(require('path'));
 
-module.exports = Ferdium => {
+module.exports = (Ferdium,settings) => {
+  // adapted from the franz-custom-website recipe, for opening
+  // links according to  the user's preference (Ferdium/ext.browser)
+  document.addEventListener(
+    'click',
+    event => {
+      const link = event.target.closest('a');
+      const button = event.target.closest('button');
+
+      if (link || button) {
+        const url = link
+          ? link.getAttribute('href')
+          : button.getAttribute('title');
+
+        // check if we have a valid URL that is not a script nor an image:
+        if (url && url !== '#' && !Ferdium.isImage(link)) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (settings.trapLinkClicks === true) {
+            window.location.href = url;
+          } else {
+            Ferdium.openNewWindow(url);
+          }
+        }
+      }
+    },
+    true,
+  );
+
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"]');
-    Ferdium.setBadge(
-      element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
-    );
+    if (element) {
+      Ferdium.setBadge(
+        element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
+      );
+    }
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -4,7 +4,7 @@ function _interopRequireDefault(obj) {
 
 const _path = _interopRequireDefault(require('path'));
 
-module.exports = (Ferdium,settings) => {
+module.exports = (Ferdium, settings) => {
   // adapted from the franz-custom-website recipe, for opening
   // links according to  the user's preference (Ferdium/ext.browser)
   document.addEventListener(


### PR DESCRIPTION
Please ensure you've completed all of the following.

- [x ] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x ] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
Since a few months certain links on instagram.com have started to open in the external browser, regardless of the service preference to open links in Ferdium. This issue is fixed with an adaptation of the event filter in the custom website recipe, modified to ignore NULL and script links (`#`).

Also fixes an occasional `element == null` dereference in getMessages().

Fixes: https://github.com/ferdium/ferdium-app/issues/1304

