### PR TITLE
Update Skype's webview.js for file downloads

### DIFF
--- a/recipes/skype/package.json
+++ b/recipes/skype/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skype",
   "name": "Skype",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.skype.com/",

--- a/recipes/skype/package.json
+++ b/recipes/skype/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skype",
   "name": "Skype",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.skype.com/",

--- a/recipes/skype/package.json
+++ b/recipes/skype/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skype",
   "name": "Skype",
-  "version": "3.7.0",
+  "version": "3.6.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.skype.com/",

--- a/recipes/skype/webview.js
+++ b/recipes/skype/webview.js
@@ -53,7 +53,10 @@ module.exports = (Ferdium, settings) => {
         if (url.includes('api.asm.skype.com')) {
           // Always open file downloads in Ferdium, rather than the external browser
           window.location.href = url;
-        } else if (settings.trapLinkClicks === true) {
+          return;
+        }
+
+        if (settings.trapLinkClicks === true) {
           window.location.href = url;
         } else {
           Ferdium.openNewWindow(url);

--- a/recipes/skype/webview.js
+++ b/recipes/skype/webview.js
@@ -50,11 +50,10 @@ module.exports = (Ferdium, settings) => {
         event.preventDefault();
         event.stopPropagation();
 
-        if (url.includes("api.asm.skype.com")) {
+        if (url.includes('api.asm.skype.com')) {
           // Always open file downloads in Ferdium, rather than the external browser
           window.location.href = url;
-        }
-        else if (settings.trapLinkClicks === true) {
+        } else if (settings.trapLinkClicks === true) {
           window.location.href = url;
         } else {
           Ferdium.openNewWindow(url);

--- a/recipes/skype/webview.js
+++ b/recipes/skype/webview.js
@@ -50,7 +50,11 @@ module.exports = (Ferdium, settings) => {
         event.preventDefault();
         event.stopPropagation();
 
-        if (settings.trapLinkClicks === true) {
+        if (url.includes("api.asm.skype.com")) {
+          // Always open file downloads in Ferdium, rather than the external browser
+          window.location.href = url;
+        }
+        else if (settings.trapLinkClicks === true) {
           window.location.href = url;
         } else {
           Ferdium.openNewWindow(url);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

Added code so that file downloads in Skype will always open in Ferdium rather than an external browser. File downloads are handled by Skype as URLs, but they're different from links to external websites, as rather than opening a page it's just a redirect for a download from the Skype servers. Opening file downloads in Ferdium should be the expected behavior. (The file download might not even work if opened in an external browser.)

This now means users can have “Open URLs in Ferdium” disabled, so that they can visit external links in their main browser, while still having the proper file download behavior.