### PR TITLE
feat: support for the new slack ui

### DIFF
--- a/recipes/slack/package.json
+++ b/recipes/slack/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slack",
   "name": "Slack",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.slack.com",

--- a/recipes/slack/webview.js
+++ b/recipes/slack/webview.js
@@ -38,12 +38,23 @@ module.exports = Ferdium => {
   const getTeamIcon = function getTeamIcon(count = 0) {
     let countTeamIconCheck = count;
     let bgUrl = null;
-    const teamMenu = document.querySelector(
+    // INFO: A new Slack UI was introduced in August 2023 and will be rolled out gradually,
+    // therefore we need to support both old and new UI for the time being
+    // See more: https://slack.com/blog/productivity/a-redesigned-slack-built-for-focus
+    const oldSlackUiTeamMenu = document.querySelector(
       '#team-menu-trigger, .p-ia__sidebar_header__team_name',
     );
+    const newSlackUiTeamMenu = document.querySelector(
+      '.p-ia4_home_header_menu__button',
+    );
 
-    if (teamMenu) {
-      teamMenu.click();
+    if (oldSlackUiTeamMenu || newSlackUiTeamMenu) {
+      if (oldSlackUiTeamMenu) {
+        oldSlackUiTeamMenu.click();
+      } else if (newSlackUiTeamMenu) {
+        newSlackUiTeamMenu.click();
+      }
+
       const icon = document.querySelector('.c-team_icon');
 
       if (icon) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- update selector for team menu to work with new and old slack ui
- bump slack recipe to v1.6.0

References https://github.com/ferdium/ferdium-app/issues/1371

#### Screenshots

Slack service has the icon again:
![Screenshot from 2023-09-23 09-29-10-obfuscated](https://github.com/ferdium/ferdium-recipes/assets/16797721/a96b8fbb-dc95-4a8b-ab93-052e58abfde4)
