### PR TITLE
fix: featured json pointing to wrong google calendar recipe id

### DIFF
--- a/featured.json
+++ b/featured.json
@@ -2,7 +2,7 @@
   "discord",
   "gitter",
   "gmail",
-  "googlecalendar",
+  "google-calendar",
   "hangouts",
   "mattermost",
   "messenger",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
- change `googlecalendar` to `google-calendar` in `featured.json`
