### PR TITLE
Handle Discord download links within Ferdium

### DIFF
--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discord.com/login",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -52,12 +52,11 @@ module.exports = (Ferdium, settings) => {
           event.preventDefault();
           event.stopPropagation();
 
-          if (url.includes('discordapp.com/attachments/')) {
+          if (
             // Always open file downloads in Ferdium, rather than the external browser
-            window.location.href = url;
-            return;
-          }
-          if (settings.trapLinkClicks === true) {
+            url.includes('discordapp.com/attachments/') ||
+            settings.trapLinkClicks === true
+          ) {
             window.location.href = url;
           } else {
             Ferdium.openNewWindow(url);

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -53,9 +53,9 @@ module.exports = (Ferdium, settings) => {
           event.stopPropagation();
 
           if (url.includes('discordapp.com/attachments/')) {
-          // Always open file downloads in Ferdium, rather than the external browser
-          window.location.href = url;
-          return;
+            // Always open file downloads in Ferdium, rather than the external browser
+            window.location.href = url;
+            return;
           }
           if (settings.trapLinkClicks === true) {
             window.location.href = url;

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -52,6 +52,11 @@ module.exports = (Ferdium, settings) => {
           event.preventDefault();
           event.stopPropagation();
 
+          if (url.includes('discordapp.com/attachments/')) {
+          // Always open file downloads in Ferdium, rather than the external browser
+          window.location.href = url;
+          return;
+          }
           if (settings.trapLinkClicks === true) {
             window.location.href = url;
           } else {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

Added code to Discord's webview.js so that file downloads will always be opened by Ferdium instead of an external browser, even if the user wants most web links to open outside of Ferdium.