### PR TITLE
Make the validation checks more noticeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 Recipes are small scripts that are responsible for providing the connection between your services (e.g. WhatsApp, Gmail or Slack) and Ferdium. It provides Ferdium information like the number of current notifications, handles enabling dark mode and may otherwise improve your experience with the service.
 
-## Creating and adding your own recipes
+## Creating, adding, and editing recipes
+
+**Important:** Please make sure to run `pnpm lint:fix && pnpm reformat-files && pnpm package` before submitting.
 
 * [Overview / How to create a Ferdium integration](docs/integration.md)
 * [How to update/change recipes](docs/updating.md)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Recipes are small scripts that are responsible for providing the connection betw
 
 ## Creating, adding, and editing recipes
 
-**Important:** Please make sure to run `pnpm lint:fix && pnpm reformat-files && pnpm package` before submitting.
+**Important:** Please make sure to run `pnpm validate` before submitting.
 
 * [Overview / How to create a Ferdium integration](docs/integration.md)
 * [How to update/change recipes](docs/updating.md)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "is-ci || husky install",
+    "validate": "pnpm lint:fix && pnpm reformat-files && pnpm package",
     "package": "node scripts/package.js",
     "create": "node scripts/create.js",
     "lint": "eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->

Put the validation checks in a more noticeable place.

I've noticed a lot of PRs that fail the checks. A lot of the time, the error message says it's a `pnpm package` error message asking for a version bump, even when the `package.json` already has a version bump. It's usually because the two other commands edited the files when they were run, and if the changes weren't staged ahead of time locally, `pnpm package` sees the new changes and fails the build.

It seems that a lot of people either didn't read the validation checks in the docs, or forgot (as I did with my latest PR). So, I'm thinking it might be a good idea to tell/remind people of the validation checks and put the info in a more prominent place.