### PR TITLE
Fix message notifications in Telegram

### DIFF
--- a/recipes/telegram/index.js
+++ b/recipes/telegram/index.js
@@ -9,12 +9,12 @@ function instrumenEnvironment(webview) {
     })();
   `);
 }
-module.exports = (Ferdium) =>
+module.exports = Ferdium =>
   class Telegram extends Ferdium {
     // https://www.electronjs.org/docs/latest/api/webview-tag/#dom-events
     get events() {
       return {
-        "load-commit": "loadCommit",
+        'load-commit': 'loadCommit',
       };
     }
 

--- a/recipes/telegram/index.js
+++ b/recipes/telegram/index.js
@@ -9,8 +9,8 @@ function instrumenEnvironment(webview) {
     })();
   `);
 }
-module.exports = (Franz) =>
-  class Telegram extends Franz {
+module.exports = (Ferdium) =>
+  class Telegram extends Ferdium {
     // https://www.electronjs.org/docs/latest/api/webview-tag/#dom-events
     events = {
       "load-commit": "loadCommit",

--- a/recipes/telegram/index.js
+++ b/recipes/telegram/index.js
@@ -12,9 +12,12 @@ function instrumenEnvironment(webview) {
 module.exports = (Ferdium) =>
   class Telegram extends Ferdium {
     // https://www.electronjs.org/docs/latest/api/webview-tag/#dom-events
-    events = {
-      "load-commit": "loadCommit",
-    };
+    get events() {
+      return {
+        "load-commit": "loadCommit",
+      };
+    }
+
     loadCommit(event) {
       instrumenEnvironment(event.target);
     }

--- a/recipes/telegram/index.js
+++ b/recipes/telegram/index.js
@@ -1,1 +1,23 @@
-module.exports = Ferdium => Ferdium;
+// https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L484
+// https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L50-L51
+function instrumenEnvironment(webview) {
+  webview.executeJavaScript(`
+    (function() {
+        if(window.electron) {
+            return;
+         }
+        
+        window.electron = { };
+    })();
+  `);
+}
+module.exports = (Franz) =>
+  class Telegram extends Franz {
+    // https://www.electronjs.org/docs/latest/api/webview-tag/#dom-events
+    events = {
+      "load-commit": "loadCommit",
+    };
+    loadCommit(event) {
+      instrumenEnvironment(event.target);
+    }
+  };

--- a/recipes/telegram/index.js
+++ b/recipes/telegram/index.js
@@ -1,5 +1,3 @@
-// https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L484
-// https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L50-L51
 function instrumenEnvironment(webview) {
   webview.executeJavaScript(`
     (function() {

--- a/recipes/telegram/package.json
+++ b/recipes/telegram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "telegram",
   "name": "Telegram",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.telegram.org",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Test evidence

Here is a [recorded screencast](https://youtu.be/Jc-QQZw5QVE) how I sent a message to myself and a notification appears in the top-right corner.

#### Description of Change
<!-- Describe your changes in detail. -->

I've identified the reason why Telegram Web A's notifications don't make it through in Ferdium:

Telegram A [sends notifications to the service worker](https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L484-L500) to handle them if push notifications are supported:

```js
  if (checkIfPushSupported()) {
    if (navigator.serviceWorker?.controller) {
      // notify service worker about new message notification
      navigator.serviceWorker.controller.postMessage({
        type: 'showMessageNotification',
        payload: {
          title,
          body,
          icon,
          chatId: chat.id,
          messageId: message.id,
          shouldReplaceHistory: true,
          isSilent: message.isSilent,
          reaction: activeReaction?.reaction,
        },
      });
    }
```

This condition is coded in the source code with the [following logic](https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/notifications.ts#L51):

```js
function checkIfPushSupported() {
  if (!IS_SERVICE_WORKER_SUPPORTED || IS_ELECTRON) return false;
```

However, the service worker encounters an issue when retrieving a list of notifications, resulting in [showNotification()](https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/serviceWorker/pushNotification.ts#L270) never being called:

```js
  if (e.data.type === 'showMessageNotification') {
    // store messageId for already shown notification
    const notification: NotificationData = e.data.payload;
    e.waitUntil((async () => {
      // Close existing notification if it is already shown
      if (notification.chatId) {
        const notifications = await self.registration.getNotifications({ tag: notification.chatId });
        notifications.forEach((n) => n.close());
      }
      // Mark this notification as shown if it was handled locally
      shownNotifications.add(notification.messageId);
      return showNotification(notification); // <-- THIS LINE
```
The root cause appears to be [self.registration.getNotifications()](https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/serviceWorker/pushNotification.ts#L265C35-L265C102) that returns a non-resolving promise:

```js
const notifications = await self.registration.getNotifications({ tag: notification.chatId });
```

This might be due to an Electron bug, although I didn't dive deeper into its specifics.

A solution might be to fix detecting whether [the runtime is Electron](https://github.com/Ajaxy/telegram-tt/blob/8fc3df855df4a1d9914e90e9e4ac8c85c2d3dd61/src/util/windowEnvironment.ts#L39) by instrumenting `window` with the `electron` property. This modification can only be performed from `index.js`, which has the ability to inject a JavaScript snippet prior to the loading of Telegram Web A. Initiating this from `webview.js` is not feasible as, typically, an app in the webview has already been initialized.