### PR TITLE
Messenger: Add color definition for incoming message bubbles.

### DIFF
--- a/recipes/messenger/darkmode.css
+++ b/recipes/messenger/darkmode.css
@@ -3,6 +3,7 @@
 :root,
 .__fb-light-mode {
   --card-background: #1e1e1e;
+  --chat-incoming-message-bubble-background-color: #292929;
   --comment-background: #292929;
   --comment-footer-background: #333;
   --card-background-flat: #292929;

--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
  - (That file doesn't exist in this repo.)
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Messenger made a change to add a new color definition for incoming message bubbles, and as a result, they are now white with gray text, and thus difficult and painful to read. This CSS change adds that color definition with the previously used message color to correct that.

Thanks kindly! 😊
