### PR TITLE
prevent pulling archived chats unread count

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -17,7 +17,7 @@ module.exports = Ferdium => {
       const query = store.getAll();
       query.onsuccess = event => {
         for (const chat of event.target.result) {
-          if (chat.unreadCount > 0) {
+          if (chat.unreadCount > 0 && !chat.archive) {
             if (chat.muteExpiration != 0 || chat.isAutoMuted) {
               unreadMutedCount += chat.unreadCount;
             } else {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
preventing the Whatsapp unread count from pulling the count of archived chats.

details:
as mentioned in this issue [#1118](https://github.com/ferdium/ferdium-app/issues/1118) which was fixed before but then the problem comeback after this commit [Fix WhatsApp count](https://github.com/ferdium/ferdium-recipes/commit/fd169b7b2ad80abce5b044909d5234f0ea6a1c27) as it solved the count but returned back to counting archived chats

I have opened the issue again before I fix it: [#451](https://github.com/ferdium/ferdium-recipes/issues/451)
