### PR TITLE
Update GroupMe DOM filtering to use latest web app conventions

### DIFF
--- a/recipes/groupme/package.json
+++ b/recipes/groupme/package.json
@@ -1,7 +1,7 @@
 {
   "id": "groupme",
   "name": "GroupMe",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.groupme.com",

--- a/recipes/groupme/webview.js
+++ b/recipes/groupme/webview.js
@@ -7,20 +7,20 @@ const _path = _interopRequireDefault(require('path'));
 module.exports = Ferdium => {
   const getMessages = () => {
     // array-ify the list of conversations
-    const allConversations = [
-      ...document.querySelectorAll('#tray .tray-list .list-item'),
+    const unreadConversations = [
+      ...document.querySelectorAll('#tray .tray-list .list-item.unread'),
     ];
     // for each conversation on the list...
-    const filteredConversations = allConversations.filter(e => {
-      // keep it on the list if [1] it has unread messages (not .ng-hide), and [2] it isn't muted (not .overlay)
+    const filteredConversations = unreadConversations.filter(e => {
+      // keep it on the list if it isn't muted (not .muted)
       return (
-        !e.innerHTML.includes('ng-hide') && !e.innerHTML.includes('overlay')
+        !e.innerHTML.includes('muted')
       );
     });
-    const unreadConversations = filteredConversations.length;
+    const unreadUnmutedConversations = filteredConversations.length;
 
     // set Ferdium badge
-    Ferdium.setBadge(unreadConversations);
+    Ferdium.setBadge(unreadUnmutedConversations);
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/groupme/webview.js
+++ b/recipes/groupme/webview.js
@@ -13,9 +13,7 @@ module.exports = Ferdium => {
     // for each conversation on the list...
     const filteredConversations = unreadConversations.filter(e => {
       // keep it on the list if it isn't muted (not .muted)
-      return (
-        !e.innerHTML.includes('muted')
-      );
+      return !e.innerHTML.includes('muted');
     });
     const unreadUnmutedConversations = filteredConversations.length;
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
<!-- Describe your changes in detail. -->
The previous code for this recipe implies that the GroupMe web app used to use Angular(JS), given that it was filtering based on an .ng-hide class. In use, the plugin was simply returning all conversation threads, rather than filtering for unread and unmuted conversations. So if there were 7 total, read conversations, the notification badge showed 7.

This update queries for conversations that have the much more direct .unread class and also do not contain the muted class inside them. This has made the notification badge count accurate for me.