### PR TITLE
Fix Zoho Mail badge

### DIFF
--- a/recipes/zoho/package.json
+++ b/recipes/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoho",
   "name": "Zoho Mail",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.zoho.com/mail/login.html",

--- a/recipes/zoho/webview-unsafe.js
+++ b/recipes/zoho/webview-unsafe.js
@@ -1,12 +1,10 @@
-// wait for Ferdium and Zoho Mail to initialize
-if (
-  Object.prototype.hasOwnProperty.call(window, 'ferdium') &&
-  Object.prototype.hasOwnProperty.call(window.ferdium, 'setBadge') &&
-  Object.prototype.hasOwnProperty.call(window, 'zmNCenter') &&
-  Object.prototype.hasOwnProperty.call(window, 'zmfolAction')
-) {
-  const unreadNotifications = window.zmNCenter.counter.count(); // General Notifications by Zoho (Bell Icon)
-  const unreadMail = window.zmfolAction.getUnreadViewCount(); // Unread messages count
-
-  window.ferdium.setBadge(unreadMail, unreadNotifications);
+// Wait for Ferdium to initialize
+if (window.ferdium?.setBadge !== undefined) {
+  window.ferdium.setBadge(
+    window.ferdium.safeParseInt(window.zmfolAction?.getUnreadViewCount()),
+    window.ferdium.safeParseInt(
+      window.zmTopBar?.topBandElements()?.notification?.children
+        ?.notificationBadge?.textContent,
+    ),
+  );
 }

--- a/recipes/zoho/webview-unsafe.js
+++ b/recipes/zoho/webview-unsafe.js
@@ -1,7 +1,10 @@
 // Wait for Ferdium to initialize
 if (window.ferdium?.setBadge !== undefined) {
   window.ferdium.setBadge(
-    window.ferdium.safeParseInt(window.zmfolAction?.getUnreadViewCount()),
+    window.ferdium.safeParseInt(window.zmfolAction?.getUnreadViewCount()) +
+      window.ferdium.safeParseInt(
+        document.querySelector('#wms_menu_unreadchats_cnt')?.textContent,
+      ),
     window.ferdium.safeParseInt(
       window.zmTopBar?.topBandElements()?.notification?.children
         ?.notificationBadge?.textContent,


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-recipes/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

As `window.zmNCenter` which was used to get notifications count for the badge's indirect notifications part does not exist anymore, badge for Zoho Mail was not working.

The solution was to retrieve notifications count differently and to exclude Zoho Mail specific `window` properties from the `if` condition so the badge would be affected only partially if one of the used Zoho Mail `window` properties gets removed in the future. For example, if `zmTopBar` will be removed from `window`, retrieval of the direct messages count would
still work.

Additionally unread chats count was added to Zoho Mail badge's direct notifications.