### PR TITLE
fix badge for Instagram

### DIFF
--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram-direct-messages/webview.js
+++ b/recipes/instagram-direct-messages/webview.js
@@ -14,7 +14,9 @@ module.exports = Ferdium => {
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"] span');
     Ferdium.setBadge(
-      element && element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
+      element && element.textContent
+        ? Ferdium.safeParseInt(element.textContent)
+        : 0,
     );
   };
 

--- a/recipes/instagram-direct-messages/webview.js
+++ b/recipes/instagram-direct-messages/webview.js
@@ -14,7 +14,7 @@ module.exports = Ferdium => {
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"] span');
     Ferdium.setBadge(
-      element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
+      element && element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
     );
   };
 

--- a/recipes/instagram-direct-messages/webview.js
+++ b/recipes/instagram-direct-messages/webview.js
@@ -12,7 +12,7 @@ setInterval(() => {
 
 module.exports = Ferdium => {
   const getMessages = () => {
-    const element = document.querySelector('a[href^="/direct/inbox"]');
+    const element = document.querySelector('a[href^="/direct/inbox"] span');
     Ferdium.setBadge(
       element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
     );

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.4",
+  "version": "2.5.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -41,11 +41,10 @@ module.exports = (Ferdium, settings) => {
 
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"] span');
-    if (element) {
-      Ferdium.setBadge(
-        element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
-      );
-    }
+    Ferdium.setBadge(
+      element && element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
+    );
+    
   };
 
   Ferdium.loop(getMessages);

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -40,7 +40,7 @@ module.exports = (Ferdium, settings) => {
   );
 
   const getMessages = () => {
-    const element = document.querySelector('a[href^="/direct/inbox"]');
+    const element = document.querySelector('a[href^="/direct/inbox"] span');
     if (element) {
       Ferdium.setBadge(
         element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,

--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -42,9 +42,10 @@ module.exports = (Ferdium, settings) => {
   const getMessages = () => {
     const element = document.querySelector('a[href^="/direct/inbox"] span');
     Ferdium.setBadge(
-      element && element.textContent ? Ferdium.safeParseInt(element.textContent) : 0,
+      element && element.textContent
+        ? Ferdium.safeParseInt(element.textContent)
+        : 0,
     );
-    
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change
I have fixed the badge of notifications for the Instagram and Instagram-direct-messages applications. The query selector now directly retrieves the value within the <span> that contains the number of notifications.
