### PR TITLE
Adds Spaces and Chat badges to countImportant

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "doc": "docs"
   },
   "engines": {
-    "node": "20.9.0",
-    "pnpm": "8.10.0"
+    "node": "^20.9.0",
+    "pnpm": "^8.10.0"
   },
   "volta": {
-    "node": "20.9.0",
-    "pnpm": "8.10.0"
+    "node": "^20.9.0",
+    "pnpm": "^8.10.0"
   },
   "engine-strict": true,
   "packageManager": "pnpm@8.10.0",

--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.7.0",
+  "version": "1.6.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -19,7 +19,7 @@ module.exports = Ferdium => {
     let countNonImportant = 0;
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
     const spaceAndChatBadges = document.querySelectorAll('span.XU.aH6');
-    
+
     if (inboxLinks.length > 0) {
       const { parentNode } = inboxLinks[0];
       if (parentNode) {
@@ -44,9 +44,12 @@ module.exports = Ferdium => {
       }
     }
 
-    if(spaceAndChatBadges.length > 0) {
-      const arr = Array.from(spaceAndChatBadges);
-      const spaceAndChatCount = arr.reduce((acc, e) => Ferdium.safeParseInt(e.getInnerHTML())+acc, 0)
+    if (spaceAndChatBadges.length > 0) {
+      const arr = [...spaceAndChatBadges];
+      const spaceAndChatCount = arr.reduce(
+        (acc, e) => Ferdium.safeParseInt(e.getInnerHTML()) + acc,
+        0,
+      );
       countImportant += spaceAndChatCount;
     }
 

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -18,6 +18,8 @@ module.exports = Ferdium => {
     let countImportant = 0;
     let countNonImportant = 0;
     const inboxLinks = document.querySelectorAll('.J-Ke.n0');
+    const spaceAndChatBadges = document.querySelectorAll('span.XU.aH6');
+    
     if (inboxLinks.length > 0) {
       const { parentNode } = inboxLinks[0];
       if (parentNode) {
@@ -41,6 +43,13 @@ module.exports = Ferdium => {
         }
       }
     }
+
+    if(spaceAndChatBadges.length > 0) {
+      const arr = Array.from(spaceAndChatBadges);
+      const spaceAndChatCount = arr.reduce((acc, e) => Ferdium.safeParseInt(e.getInnerHTML())+acc, 0)
+      countImportant += spaceAndChatCount;
+    }
+
     Ferdium.setBadge(countImportant, countNonImportant);
   };
 


### PR DESCRIPTION
Thanks to all y'all for this recipe!

I use it with G-Suite and have missed a few important messages from only seeing Ferdium count emails and not chat messages.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

Makes the badge account for chat messages from DMs and Spaces.

Also, unlocks version lock. I ran everything just fine with Node 20.10.0 and pnpm 8.12.1
