### PR TITLE
Add a new selector for indirect GitHub notification badge

### DIFF
--- a/recipes/github/package.json
+++ b/recipes/github/package.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "GitHub",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://github.com/notifications",

--- a/recipes/github/webview.js
+++ b/recipes/github/webview.js
@@ -15,7 +15,8 @@ module.exports = Ferdium => {
           ?.textContent,
       ) + Ferdium.safeParseInt(newCountMatch ? newCountMatch[0] : 0),
       document.querySelectorAll(
-        '#AppHeader-notifications-button.AppHeader-button--hasIndicator',
+        '#AppHeader-notifications-button.AppHeader-button--hasIndicator, ' +
+          '[data-target="notification-indicator.badge"]:not([hidden])',
       ).length,
     );
   };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

GitHub recipe was updated to append a new selector for indirect notifications badge that works when an user navigates to GitHub Gist.
