### PR TITLE
GitHub recipe  - fix unread count retrieval from new notififications link

### DIFF
--- a/recipes/github/package.json
+++ b/recipes/github/package.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "GitHub",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://github.com/notifications",

--- a/recipes/github/webview.js
+++ b/recipes/github/webview.js
@@ -5,10 +5,10 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
-  const newCountMatch = document
-    .querySelector('a.h6[href="/notifications?query="]')
-    ?.textContent?.match(/\d+/);
   const getMessages = () => {
+    const newCountMatch = document
+      .querySelector('a.h6[href^="/notifications?query="]')
+      ?.textContent?.match(/\d+/);
     Ferdium.setBadge(
       Ferdium.safeParseInt(
         document.querySelector('.filter-list.js-notification-inboxes .count')


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

GitHub recipe's `webview.js` was updated to move `newCountMatch` definition within `getMessages` so unread messages badge would be correctly updated when the "x new notification(s)" link appears.
