### PR TITLE
rocketchat: fix unread counter disappearing

### DIFF
--- a/recipes/rocketchat/package.json
+++ b/recipes/rocketchat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "rocketchat",
   "name": "Rocket.Chat",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.rocket.chat",

--- a/recipes/rocketchat/webview.js
+++ b/recipes/rocketchat/webview.js
@@ -6,19 +6,19 @@ const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
   const getMessages = () => {
-    const directMessages = document.querySelectorAll('.rcx-badge');
+    const title = document.querySelector('title');
+    const matches = title.textContent.match(/^\((\S*?)\)/);
 
-    let directMessagesCount = 0;
-
-    for (const directMessage of directMessages) {
-      directMessagesCount += Ferdium.safeParseInt(directMessage.textContent);
+    if (matches) {
+      const count = Ferdium.safeParseInt(matches[1], 10);
+      if (count) {
+        Ferdium.setBadge(count);
+      } else {
+        Ferdium.setBadge(0, 1);
+      }
+    } else {
+      Ferdium.setBadge(0);
     }
-
-    const indirectMessagesCount = Math.round(
-      document.querySelectorAll('.rcx-sidebar-item--highlighted').length,
-    );
-
-    Ferdium.setBadge(directMessagesCount, indirectMessagesCount);
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/HEAD/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/HEAD/CODE_OF_CONDUCT.md) that this project adheres to.

#### Description of Change

<!-- Describe your changes in detail. -->

At some point, Rocketchat started to remove the DOM elements for channels from the sidebar which are not in the current viewport (i.e. scrolled out of view). This means that the current approach of counting `.rcx-badge` and `.rcx-sidebar-item--highlighted` elements does not work reliably, since they might not exist.

The recipe now uses the information in the title bar, which is updated by Rocketchat itself. 