### PR TITLE
fix: gmail doubled notifications

### DIFF
--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -15,47 +15,14 @@ module.exports = Ferdium => {
   }
 
   const getMessages = () => {
-    let countImportant = 0;
-    let countNonImportant = 0;
-    const inboxLinks = document.querySelectorAll('.J-Ke.n0');
-    const spaceAndChatBadges = document.querySelectorAll(
-      'div.Xa.bSyoAf span.XU',
+    const mailChatMeetBadges = document.querySelectorAll('span.XU.aH6');
+
+    const mailChatMeetCounts = [...mailChatMeetBadges].reduce(
+      (acc, e) => Ferdium.safeParseInt(e.getInnerHTML()) + acc,
+      0,
     );
 
-    if (inboxLinks.length > 0) {
-      const { parentNode } = inboxLinks[0];
-      if (parentNode) {
-        const parentNodeOfParentNode = parentNode.parentNode;
-        if (parentNodeOfParentNode) {
-          const unreadCounts = parentNodeOfParentNode.querySelectorAll('.bsU');
-          if (unreadCounts.length > 0) {
-            const unreadCount = unreadCounts[0].textContent;
-            if (unreadCount.includes(':')) {
-              const counts = unreadCount
-                .split(':')
-                .map(s => Ferdium.safeParseInt(s.replaceAll(/[^\p{N}]/gu, '')));
-              countImportant = counts[0];
-              countNonImportant = counts[1] - counts[0];
-            } else {
-              countImportant = Ferdium.safeParseInt(
-                unreadCount.replaceAll(/[^\p{N}]/gu, ''),
-              );
-            }
-          }
-        }
-      }
-    }
-
-    if (spaceAndChatBadges.length > 0) {
-      const arr = [...spaceAndChatBadges];
-      const spaceAndChatCount = arr.reduce(
-        (acc, e) => Ferdium.safeParseInt(e.getInnerHTML()) + acc,
-        0,
-      );
-      countImportant += spaceAndChatCount;
-    }
-
-    Ferdium.setBadge(countImportant, countNonImportant);
+    Ferdium.setBadge(mailChatMeetCounts);
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Current recipe for gmail doubles any kind of notifications. This change fixes that, however personally I have no use for 'notImportant' notifications (aka blue badge), and, whats more important - I couldn't find examples that would allow me to keep it and test it out, so I got rid of that.

My solutions sums up the counts appearing on Mail, Chat and Meet buttons - clean and simple.
