### PR TITLE
porting to use ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "is-ci || husky install",
     "validate": "pnpm lint:fix && pnpm reformat-files && pnpm package",
     "package": "node scripts/package.js",
-    "create": "node scripts/create.js",
+    "create": "node scripts/create.mjs",
     "lint": "eslint \"{recipes,scripts}/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "pnpm lint --fix",
     "reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,json,scss}\"",

--- a/scripts/create.mjs
+++ b/scripts/create.mjs
@@ -3,9 +3,10 @@
 /**
  * Create a new recipe for your service
  */
-const fs = require('fs-extra');
-const path = require('path');
-const open = require('open');
+import fs from 'fs-extra';
+
+import path from 'path';
+import open from 'open';
 
 if (process.argv.length < 3) {
   console.log(`Usage: pnpm create <Recipe name> [Folder name]
@@ -49,7 +50,7 @@ const pascalCasedName = toPascalCase(recipe); // PascalCased recipe ID only cont
   const recipesFolder = path.join(userData, folderName, 'recipes');
   const devRecipeFolder = path.join(recipesFolder, 'dev');
   const newRecipeFolder = path.join(devRecipeFolder, recipe);
-  const sampleRecipe = path.join(__dirname, 'sample_recipe');
+  const sampleRecipe = path.join(import.meta.dirname, 'sample_recipe'); // Starting with Node.js 20.11 / 21.2, you can use import.meta.dirname
 
   // Make sure dev recipe folder exists
   if (!fs.existsSync(recipesFolder)) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

with the upgrade of the [open](https://www.npmjs.com/package/open) package to: open@9.1.0 (six months ago)
the `/scripts/create.js` is invalid because this version is [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) only.

i ported the entire app to ESM. 
