### PR TITLE
Hides the sidebar of distractions

### DIFF
--- a/recipes/instagram-direct-messages/service.css
+++ b/recipes/instagram-direct-messages/service.css
@@ -11,3 +11,7 @@
 #react-root>section .i0EQd {
     max-width: unset !important;
 }
+
+[class="xopu45v xu3j5b3 xm81vs4 x1vjfegm"] {
+    display: none; 
+} 


### PR DESCRIPTION
That is only my suggestion, so I don't pressure to have this accepted, however "Instagram Direct Messages" service could work in a more similar manner to Distraction Free Instagram app, whereas those that want full features could add the regular Instagram service instead.