### PR TITLE
Whatsapp - Disable max-width on new main app selector

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/service.css
+++ b/recipes/whatsapp/service.css
@@ -13,6 +13,6 @@
 }
 
 /* fix for blank spaces regarding view width on screens larger than 1080p */
-.app-wrapper-web ._1jJ70, .app-wrapper-web ._aigs {
+.app-wrapper-web ._aigs {
   max-width: none !important;
 }

--- a/recipes/whatsapp/service.css
+++ b/recipes/whatsapp/service.css
@@ -13,6 +13,6 @@
 }
 
 /* fix for blank spaces regarding view width on screens larger than 1080p */
-.app-wrapper-web ._1jJ70 {
+.app-wrapper-web ._1jJ70, .app-wrapper-web ._aigs {
   max-width: none !important;
 }


### PR DESCRIPTION
Add a new selector class `.app-wrapper-web ._aigs` to disable `max-width`

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Add `.app-wrapper-web ._aigs` as a new selector to disable `max-width`.

Resolves ferdium/ferdium-app#1664
