### PR TITLE
Fix notion calendar login

### DIFF
--- a/recipes/notion-calendar/package.json
+++ b/recipes/notion-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "notion-calendar",
   "name": "Notion Calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://calendar.notion.so/",

--- a/recipes/notion-calendar/webview-unsafe.js
+++ b/recipes/notion-calendar/webview-unsafe.js
@@ -1,0 +1,7 @@
+// Workaround for Notion's login window with Google OAuth
+if (window.location.href === 'https://calendar.notion.so/login') {
+  window.open = function (url) {
+    const newUrl = url.replace('popup=true', 'popup=false');
+    window.location.href = newUrl;
+  };
+}

--- a/recipes/notion-calendar/webview.js
+++ b/recipes/notion-calendar/webview.js
@@ -5,12 +5,6 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
-  // TODO: If your SNAME service has unread messages, uncomment these lines to implement the logic for updating the badges
-  // const getMessages = () => {
-  //   // TODO: Insert your notification-finding code here
-  //   Ferdium.setBadge(0, 0);
-  // };
-  // Ferdium.loop(getMessages);
-
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
 };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

This is a workaround fix to Notion Calendar login with Google - we need to capture and change the login URL (`popup=true` to `popup=false`) so that the user can login inside the webview.
