### PR TITLE
chore: bump all recipes minor versions

### DIFF
--- a/recipes/BlueBubbles/package.json
+++ b/recipes/BlueBubbles/package.json
@@ -1,7 +1,7 @@
 {
   "id": "BlueBubbles",
   "name": "BlueBubbles",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bluebubbles.app/web/#/"

--- a/recipes/NewsBlur/package.json
+++ b/recipes/NewsBlur/package.json
@@ -1,7 +1,7 @@
 {
   "id": "NewsBlur",
   "name": "NewsBlur",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://newsblur.com",

--- a/recipes/OVHCloud/package.json
+++ b/recipes/OVHCloud/package.json
@@ -1,7 +1,7 @@
 {
   "id": "OVHCloud",
   "name": "OVH Cloud",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.ovh.com/auth"

--- a/recipes/TickTick/package.json
+++ b/recipes/TickTick/package.json
@@ -1,7 +1,7 @@
 {
   "id": "TickTick",
   "name": "TickTick",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.ticktick.com/#p/inbox/tasks"

--- a/recipes/air-droid/package.json
+++ b/recipes/air-droid/package.json
@@ -1,7 +1,7 @@
 {
   "id": "air-droid",
   "name": "AirDroid",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "http://web.airdroid.com/",

--- a/recipes/airmessage/package.json
+++ b/recipes/airmessage/package.json
@@ -1,7 +1,7 @@
 {
   "id": "airmessage",
   "name": "AirMessage",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.airmessage.org/"

--- a/recipes/airtable/package.json
+++ b/recipes/airtable/package.json
@@ -1,7 +1,7 @@
 {
   "id": "airtable",
   "name": "Airtable",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/transnat/recipe-airtable",
   "config": {

--- a/recipes/alibaba-chat/package.json
+++ b/recipes/alibaba-chat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "alibaba-chat",
   "name": "Alibaba Chat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://message.alibaba.com/message/messenger.htm"

--- a/recipes/amazon-web-services/package.json
+++ b/recipes/amazon-web-services/package.json
@@ -1,7 +1,7 @@
 {
   "id": "amazon-web-services",
   "name": "Amazon Web Services",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "aliases": [
     "aws"

--- a/recipes/amazon-work-mail/package.json
+++ b/recipes/amazon-work-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "amazon-work-mail",
   "name": "Amazon WorkMail",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.awsapps.com/mail",

--- a/recipes/android-messages/package.json
+++ b/recipes/android-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "android-messages",
   "name": "Android Messages",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messages.google.com/web",

--- a/recipes/anonaddy/package.json
+++ b/recipes/anonaddy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "anonaddy",
   "name": "addy.io",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.addy.io/",

--- a/recipes/anydo/package.json
+++ b/recipes/anydo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "anydo",
   "name": "Any.do",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/chappy84/recipe-anydo",
   "config": {

--- a/recipes/asana/package.json
+++ b/recipes/asana/package.json
@@ -1,7 +1,7 @@
 {
   "id": "asana",
   "name": "Asana",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.asana.com",

--- a/recipes/awork/package.json
+++ b/recipes/awork/package.json
@@ -1,7 +1,7 @@
 {
   "id": "awork",
   "name": "Awork",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.awork.io",

--- a/recipes/azure-devops/package.json
+++ b/recipes/azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "id": "azure-devops",
   "name": "Azure DevOps",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "aliases": [
     "azdo"

--- a/recipes/badoo/package.json
+++ b/recipes/badoo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "badoo",
   "name": "Badoo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://badoo.com"

--- a/recipes/bard/package.json
+++ b/recipes/bard/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bard",
   "name": "Bard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bard.google.com/"

--- a/recipes/basecamp/package.json
+++ b/recipes/basecamp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "basecamp",
   "name": "Basecamp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://launchpad.37signals.com/"

--- a/recipes/bigbluebutton/package.json
+++ b/recipes/bigbluebutton/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bigbluebutton",
   "name": "BigBlueButton",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bigbluebutton.mycompany.com/",

--- a/recipes/binance/package.json
+++ b/recipes/binance/package.json
@@ -1,7 +1,7 @@
 {
   "id": "binance",
   "name": "Binance",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://accounts.binance.com"

--- a/recipes/bip/package.json
+++ b/recipes/bip/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bip",
   "name": "BiP",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.bip.com/",

--- a/recipes/bitbucket/package.json
+++ b/recipes/bitbucket/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bitbucket",
   "name": "BitBucket",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bitbucket.org/dashboard/overview",

--- a/recipes/bitwarden/package.json
+++ b/recipes/bitwarden/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bitwarden",
   "name": "Bitwarden",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://vault.bitwarden.com/",

--- a/recipes/bluesky/package.json
+++ b/recipes/bluesky/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bluesky",
   "name": "Bluesky",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bsky.app/"

--- a/recipes/box/package.json
+++ b/recipes/box/package.json
@@ -1,7 +1,7 @@
 {
   "id": "box",
   "name": "Box",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://account.box.com/login"

--- a/recipes/brax.me/package.json
+++ b/recipes/brax.me/package.json
@@ -1,7 +1,7 @@
 {
   "id": "brax.me",
   "name": "Brax.Me",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": "https://github.com/hafiz-muhammad/ferdium-recipes",
   "config": {

--- a/recipes/bring/package.json
+++ b/recipes/bring/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bring",
   "name": "Bring!",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.getbring.com"

--- a/recipes/buffer/package.json
+++ b/recipes/buffer/package.json
@@ -1,7 +1,7 @@
 {
   "id": "buffer",
   "name": "Buffer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "GPL",
   "config": {
     "serviceURL": "https://buffer.com",

--- a/recipes/bugzilla/package.json
+++ b/recipes/bugzilla/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bugzilla",
   "name": "Bugzilla",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [],
   "config": {

--- a/recipes/campuswire/package.json
+++ b/recipes/campuswire/package.json
@@ -1,7 +1,7 @@
 {
   "id": "campuswire",
   "name": "Campuswire",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://campuswire.com/c",

--- a/recipes/canva/package.json
+++ b/recipes/canva/package.json
@@ -1,7 +1,7 @@
 {
   "id": "canva",
   "name": "Canva",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://canva.com"

--- a/recipes/canvas/package.json
+++ b/recipes/canvas/package.json
@@ -1,7 +1,7 @@
 {
   "id": "canvas",
   "name": "Canvas",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.instructure.com/",

--- a/recipes/chatgpt/package.json
+++ b/recipes/chatgpt/package.json
@@ -1,7 +1,7 @@
 {
   "id": "chatgpt",
   "name": "ChatGPT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://chat.openai.com/chat"

--- a/recipes/chatra/package.json
+++ b/recipes/chatra/package.json
@@ -1,7 +1,7 @@
 {
   "id": "chatra",
   "name": "Chatra",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.chatra.io/",

--- a/recipes/chatwithgpt/package.json
+++ b/recipes/chatwithgpt/package.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwithgpt",
   "name": "Chat with GPT",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.chatwithgpt.ai/"

--- a/recipes/chatwoot/package.json
+++ b/recipes/chatwoot/package.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwoot",
   "name": "Chatwoot",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "repository": "https://github.com/maximeMD/ferdi-chatwoot",
   "config": {

--- a/recipes/chatwork/package.json
+++ b/recipes/chatwork/package.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwork",
   "name": "Chatwork",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/hideosasaki/recipe-chatwork",
   "config": {

--- a/recipes/cinny/package.json
+++ b/recipes/cinny/package.json
@@ -1,7 +1,7 @@
 {
   "id": "cinny",
   "name": "Cinny",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [
     "Matrix"

--- a/recipes/circuit/package.json
+++ b/recipes/circuit/package.json
@@ -1,7 +1,7 @@
 {
   "id": "circuit",
   "name": "Circuit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://eu.yourcircuit.com/"

--- a/recipes/ciscospark/package.json
+++ b/recipes/ciscospark/package.json
@@ -1,7 +1,7 @@
 {
   "id": "ciscospark",
   "name": "Cisco Spark",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.ciscospark.com",

--- a/recipes/citrix-workspace/package.json
+++ b/recipes/citrix-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "id": "citrix-workspace",
   "name": "Citrix Workspace",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.cloud.com",

--- a/recipes/clickup/package.json
+++ b/recipes/clickup/package.json
@@ -1,7 +1,7 @@
 {
   "id": "clickup",
   "name": "ClickUp",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.clickup.com",

--- a/recipes/cliq/package.json
+++ b/recipes/cliq/package.json
@@ -1,7 +1,7 @@
 {
   "id": "cliq",
   "name": "Cliq",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": "https://github.com/cliqgeek/recipe-cliq",
   "config": {
     "serviceURL": "https://www.zoho.com/cliq/login.html",

--- a/recipes/clockify/package.json
+++ b/recipes/clockify/package.json
@@ -1,7 +1,7 @@
 {
   "id": "clockify",
   "name": "Clockify",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://clockify.me/tracker",

--- a/recipes/clockwise/package.json
+++ b/recipes/clockwise/package.json
@@ -1,7 +1,7 @@
 {
   "id": "clockwise",
   "name": "Clockwise",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/TheKevJames/franz-recipe-clockwise",
   "config": {

--- a/recipes/clubhouse/package.json
+++ b/recipes/clubhouse/package.json
@@ -1,7 +1,7 @@
 {
   "id": "clubhouse",
   "name": "Clubhouse",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/dnlnrs/ferdi-recipe-clubhouse",
   "config": {

--- a/recipes/coinbase/package.json
+++ b/recipes/coinbase/package.json
@@ -1,7 +1,7 @@
 {
   "id": "coinbase",
   "name": "Coinbase",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/gaspergrom/Franz-services",
   "config": {

--- a/recipes/conceptboard/package.json
+++ b/recipes/conceptboard/package.json
@@ -1,7 +1,7 @@
 {
   "id": "conceptboard",
   "name": "Conceptboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.conceptboard.com/"

--- a/recipes/confluence/package.json
+++ b/recipes/confluence/package.json
@@ -1,7 +1,7 @@
 {
   "id": "confluence",
   "name": "Confluence",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/crowdin/package.json
+++ b/recipes/crowdin/package.json
@@ -1,7 +1,7 @@
 {
   "id": "crowdin",
   "name": "Crowdin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://crowdin.com/profile"

--- a/recipes/deckblue/package.json
+++ b/recipes/deckblue/package.json
@@ -1,7 +1,7 @@
 {
   "id": "deckblue",
   "name": "DeckBlue",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://deck.blue/"

--- a/recipes/deepl/package.json
+++ b/recipes/deepl/package.json
@@ -1,7 +1,7 @@
 {
   "id": "deepl",
   "name": "DeepL",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.deepl.com/translator"

--- a/recipes/dev-community/package.json
+++ b/recipes/dev-community/package.json
@@ -1,7 +1,7 @@
 {
   "id": "dev-community",
   "name": "Dev Community",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://dev.to"

--- a/recipes/devRant/package.json
+++ b/recipes/devRant/package.json
@@ -1,7 +1,7 @@
 {
   "id": "devRant",
   "name": "devRant",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/emamut/recipe-devrant",
   "config": {

--- a/recipes/devdocs/package.json
+++ b/recipes/devdocs/package.json
@@ -1,7 +1,7 @@
 {
   "id": "devdocs",
   "name": "DevDocs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://devdocs.io"

--- a/recipes/diagrams/package.json
+++ b/recipes/diagrams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "diagrams",
   "name": "Diagrams",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.diagrams.net/"

--- a/recipes/dialpad/package.json
+++ b/recipes/dialpad/package.json
@@ -1,7 +1,7 @@
 {
   "id": "dialpad",
   "name": "Dialpad",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/TheKevJames/franz-recipe-dialpad",
   "config": {

--- a/recipes/dingtalk/package.json
+++ b/recipes/dingtalk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk",
   "name": "Dingtalk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://im.dingtalk.com/",

--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discord.com/app",

--- a/recipes/discourse/package.json
+++ b/recipes/discourse/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discourse",
   "name": "Discourse",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [],
   "config": {

--- a/recipes/disqus/package.json
+++ b/recipes/disqus/package.json
@@ -1,7 +1,7 @@
 {
   "id": "disqus",
   "name": "Disqus",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://disqus.com/home/"

--- a/recipes/dockerhub/package.json
+++ b/recipes/dockerhub/package.json
@@ -1,7 +1,7 @@
 {
   "id": "dockerhub",
   "name": "Docker Hub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://hub.docker.com"

--- a/recipes/drawio/package.json
+++ b/recipes/drawio/package.json
@@ -1,7 +1,7 @@
 {
   "id": "drawio",
   "name": "Draw.io",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.diagrams.net/"

--- a/recipes/dropbox/package.json
+++ b/recipes/dropbox/package.json
@@ -1,7 +1,7 @@
 {
   "id": "dropbox",
   "name": "Dropbox",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.dropbox.com/home",

--- a/recipes/easy-redmine/package.json
+++ b/recipes/easy-redmine/package.json
@@ -1,7 +1,7 @@
 {
   "id": "easy-redmine",
   "name": "Easy Redmine",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamID}.easyredmine.com",

--- a/recipes/element/package.json
+++ b/recipes/element/package.json
@@ -1,7 +1,7 @@
 {
   "id": "element",
   "name": "Element",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "aliases": [
     "Riot.im",

--- a/recipes/elevate/package.json
+++ b/recipes/elevate/package.json
@@ -1,7 +1,7 @@
 {
   "id": "elevate",
   "name": "Elevate",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://elevate.serverdata.net"

--- a/recipes/elk/package.json
+++ b/recipes/elk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "elk",
   "name": "Elk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": "https://github.com/jalil-salame/ferdium-elk-recipe",
   "config": {

--- a/recipes/epicgames/package.json
+++ b/recipes/epicgames/package.json
@@ -1,7 +1,7 @@
 {
   "id": "epicgames",
   "name": "Epic Games Store",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.epicgames.com/id/login?lang=en_US&redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fstore%2Fen-US%2F&noHostRedirect=true"

--- a/recipes/erepublik/package.json
+++ b/recipes/erepublik/package.json
@@ -1,7 +1,7 @@
 {
   "id": "erepublik",
   "name": "eRepublik",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://erepublik.com"

--- a/recipes/evernote/package.json
+++ b/recipes/evernote/package.json
@@ -1,7 +1,7 @@
 {
   "id": "evernote",
   "name": "Evernote",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.evernote.com/Login.action"

--- a/recipes/excalidraw/package.json
+++ b/recipes/excalidraw/package.json
@@ -1,7 +1,7 @@
 {
   "id": "excalidraw",
   "name": "Excalidraw",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://excalidraw.com/",

--- a/recipes/facebook/package.json
+++ b/recipes/facebook/package.json
@@ -1,7 +1,7 @@
 {
   "id": "facebook",
   "name": "Facebook",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.facebook.com/login"

--- a/recipes/facebookpages/package.json
+++ b/recipes/facebookpages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "facebookpages",
   "name": "Facebook Pages",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://facebook.com/{teamId}/",

--- a/recipes/fandom/package.json
+++ b/recipes/fandom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "fandom",
   "name": "Fandom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.fandom.com"

--- a/recipes/fastmail/package.json
+++ b/recipes/fastmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "fastmail",
   "name": "FastMail",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.fastmail.com/mail/",

--- a/recipes/feedbin/package.json
+++ b/recipes/feedbin/package.json
@@ -1,7 +1,7 @@
 {
   "id": "feedbin",
   "name": "Feedbin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://feedbin.com/login",

--- a/recipes/feedly/package.json
+++ b/recipes/feedly/package.json
@@ -1,7 +1,7 @@
 {
   "id": "feedly",
   "name": "Feedly",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://feedly.com"

--- a/recipes/figma/package.json
+++ b/recipes/figma/package.json
@@ -1,7 +1,7 @@
 {
   "id": "figma",
   "name": "Figma",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://figma.com"

--- a/recipes/fiverr/package.json
+++ b/recipes/fiverr/package.json
@@ -1,7 +1,7 @@
 {
   "id": "fiverr",
   "name": "Fiverr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.fiverr.com/inbox/",

--- a/recipes/fleep/package.json
+++ b/recipes/fleep/package.json
@@ -1,7 +1,7 @@
 {
   "id": "fleep",
   "name": "Fleep",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://fleep.io/chat"

--- a/recipes/flock/package.json
+++ b/recipes/flock/package.json
@@ -1,7 +1,7 @@
 {
   "id": "flock",
   "name": "Flock",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/jereddowden/franz-recipe-flock",
   "config": {

--- a/recipes/flowdock/package.json
+++ b/recipes/flowdock/package.json
@@ -1,7 +1,7 @@
 {
   "id": "flowdock",
   "name": "Flowdock",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.flowdock.com/app/",

--- a/recipes/franz-custom-website/package.json
+++ b/recipes/franz-custom-website/package.json
@@ -1,7 +1,7 @@
 {
   "id": "franz-custom-website",
   "name": "Custom Website",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-custom-website",
   "config": {

--- a/recipes/freshdesk/package.json
+++ b/recipes/freshdesk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "freshdesk",
   "name": "Freshdesk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "repository": "https://github.com/fisknils/recipe-freshdesk",
   "config": {

--- a/recipes/freshrss/package.json
+++ b/recipes/freshrss/package.json
@@ -1,7 +1,7 @@
 {
   "id": "freshrss",
   "name": "FreshRSS",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/freshservice/package.json
+++ b/recipes/freshservice/package.json
@@ -1,7 +1,7 @@
 {
   "id": "freshservice",
   "name": "Freshservice",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://freshservice.com"

--- a/recipes/gadugadu/package.json
+++ b/recipes/gadugadu/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gadugadu",
   "name": "Gadu-Gadu",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.gg.pl",

--- a/recipes/gaming-on-linux/package.json
+++ b/recipes/gaming-on-linux/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gaming-on-linux",
   "name": "GamingOnLinux",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.gamingonlinux.com"

--- a/recipes/gather/package.json
+++ b/recipes/gather/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gather",
   "name": "Gather",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.gather.town/app"

--- a/recipes/gettr/package.json
+++ b/recipes/gettr/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gettr",
   "name": "Gettr",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://gettr.com"

--- a/recipes/gitea/package.json
+++ b/recipes/gitea/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gitea",
   "name": "Gitea",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/github/package.json
+++ b/recipes/github/package.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "GitHub",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://github.com/notifications",

--- a/recipes/gitlab/package.json
+++ b/recipes/gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gitlab",
   "name": "GitLab",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://gitlab.com/users/sign_in",

--- a/recipes/gitter/package.json
+++ b/recipes/gitter/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gitter",
   "name": "Gitter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://gitter.im",

--- a/recipes/glowing-bear/package.json
+++ b/recipes/glowing-bear/package.json
@@ -1,7 +1,7 @@
 {
   "id": "glowing-bear",
   "name": "Glowing Bear",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.glowing-bear.org",

--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/good-reads/package.json
+++ b/recipes/good-reads/package.json
@@ -1,7 +1,7 @@
 {
   "id": "good-reads",
   "name": "Good Reads",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.goodreads.com/"

--- a/recipes/google-calendar/package.json
+++ b/recipes/google-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-calendar",
   "name": "Google Calendar",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "MIT",
   "aliases": [
     "google-calendar",

--- a/recipes/google-classroom/package.json
+++ b/recipes/google-classroom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-classroom",
   "name": "Google Classroom",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/TanZng/ferdi-googleclassroom",
   "config": {

--- a/recipes/google-contacts/package.json
+++ b/recipes/google-contacts/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-contacts",
   "name": "Google Contacts",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://contacts.google.com/u/0/"

--- a/recipes/google-docs/package.json
+++ b/recipes/google-docs/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-docs",
   "name": "Google Docs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://docs.google.com/document/u/0/"

--- a/recipes/google-drive/package.json
+++ b/recipes/google-drive/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-drive",
   "name": "Google Drive",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "repository": "https://github.com/BrianGilbert/franz-recipe-tawk",
   "license": "MIT",
   "config": {

--- a/recipes/google-duo/package.json
+++ b/recipes/google-duo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-duo",
   "name": "Google Duo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/AnalogCyan/recipe-franz-googleduo",
   "config": {

--- a/recipes/google-groups/package.json
+++ b/recipes/google-groups/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-groups",
   "name": "Google Groups",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://groups.google.com/u/0/"

--- a/recipes/google-keep/package.json
+++ b/recipes/google-keep/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-keep",
   "name": "Google Keep",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://keep.google.com/u/0/"

--- a/recipes/google-maps/package.json
+++ b/recipes/google-maps/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-maps",
   "name": "Google Maps",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.google.com/maps"

--- a/recipes/google-meet/package.json
+++ b/recipes/google-meet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-meet",
   "name": "Google Meet",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://meet.google.com/u/0/",

--- a/recipes/google-news/package.json
+++ b/recipes/google-news/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-news",
   "name": "Google News",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://news.google.com/u/0/"

--- a/recipes/google-podcasts/package.json
+++ b/recipes/google-podcasts/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-podcasts",
   "name": "Google Podcasts",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://podcasts.google.com/u/0/"

--- a/recipes/google-presentation/package.json
+++ b/recipes/google-presentation/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-presentation",
   "name": "Google Presentation",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://docs.google.com/presentation/u/0/"

--- a/recipes/google-spreadsheets/package.json
+++ b/recipes/google-spreadsheets/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-spreadsheets",
   "name": "Google Spreadsheets",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://docs.google.com/spreadsheets/u/0/"

--- a/recipes/google-translate/package.json
+++ b/recipes/google-translate/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-translate",
   "name": "Google Translate",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://translate.google.com/u/0/"

--- a/recipes/google-voice/package.json
+++ b/recipes/google-voice/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-voice",
   "name": "Google Voice",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "config": {
     "serviceURL": "https://voice.google.com/u/0/",

--- a/recipes/gotify/package.json
+++ b/recipes/gotify/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gotify",
   "name": "Gotify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/goto/package.json
+++ b/recipes/goto/package.json
@@ -1,7 +1,7 @@
 {
   "id": "goto",
   "name": "GoTo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.goto.com/"

--- a/recipes/gotomeeting/package.json
+++ b/recipes/gotomeeting/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gotomeeting",
   "name": "Go To Meeting",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": "https://github.com/tristanplouz/ferdi-recipe-gotomeeting.git",
   "license": "MIT",
   "config": {

--- a/recipes/grammarly/package.json
+++ b/recipes/grammarly/package.json
@@ -1,7 +1,7 @@
 {
   "id": "grammarly",
   "name": "Grammarly",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.grammarly.com/"

--- a/recipes/groupme/package.json
+++ b/recipes/groupme/package.json
@@ -1,7 +1,7 @@
 {
   "id": "groupme",
   "name": "GroupMe",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.groupme.com",

--- a/recipes/guilded/package.json
+++ b/recipes/guilded/package.json
@@ -1,7 +1,7 @@
 {
   "id": "guilded",
   "name": "Guilded",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.guilded.gg/",

--- a/recipes/habitica/package.json
+++ b/recipes/habitica/package.json
@@ -1,7 +1,7 @@
 {
   "id": "habitica",
   "name": "Habitica",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/lmnet/franz-recipe-notion",
   "config": {

--- a/recipes/hacker-news/package.json
+++ b/recipes/hacker-news/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hacker-news",
   "name": "Hacker News",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://news.ycombinator.com/"

--- a/recipes/hackmd/package.json
+++ b/recipes/hackmd/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hackmd",
   "name": "HackMd",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://hackmd.io",

--- a/recipes/hangouts/package.json
+++ b/recipes/hangouts/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangouts",
   "name": "Google Chat",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com/chat/",

--- a/recipes/hangoutschat/package.json
+++ b/recipes/hangoutschat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangoutschat",
   "name": "Hangouts Chat",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "aliases": [
     "google-chat",

--- a/recipes/harvest/package.json
+++ b/recipes/harvest/package.json
@@ -1,7 +1,7 @@
 {
   "id": "harvest",
   "name": "Harvest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.harvestapp.com",

--- a/recipes/help-scout/package.json
+++ b/recipes/help-scout/package.json
@@ -1,7 +1,7 @@
 {
   "id": "help-scout",
   "name": "Help Scout",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.helpscout.com"

--- a/recipes/hey/package.json
+++ b/recipes/hey/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hey",
   "name": "Hey",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": "https://github.com/cpwood/recipe-hey",
   "config": {
     "serviceURL": "https://app.hey.com",

--- a/recipes/home-assistant/package.json
+++ b/recipes/home-assistant/package.json
@@ -1,7 +1,7 @@
 {
   "id": "home-assistant",
   "name": "Home Assistant",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true,

--- a/recipes/hostnet/package.json
+++ b/recipes/hostnet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hostnet",
   "name": "Hostnet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://appsuite.hostnet.nl/appsuite/"

--- a/recipes/hubstaff/package.json
+++ b/recipes/hubstaff/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hubstaff",
   "name": "HubStaff",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.hubstaff.com/login_now",

--- a/recipes/iCloud/package.json
+++ b/recipes/iCloud/package.json
@@ -1,7 +1,7 @@
 {
   "id": "iCloud",
   "name": "iCloud",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.icloud.com/"

--- a/recipes/iberbox/package.json
+++ b/recipes/iberbox/package.json
@@ -1,7 +1,7 @@
 {
   "id": "iberbox",
   "name": "IberBox",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://iberbox.com/login"

--- a/recipes/icloud-reminders/package.json
+++ b/recipes/icloud-reminders/package.json
@@ -1,7 +1,7 @@
 {
   "id": "icloud-reminders",
   "name": "iCloud Reminders",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.icloud.com/reminders"

--- a/recipes/icq/package.json
+++ b/recipes/icq/package.json
@@ -1,7 +1,7 @@
 {
   "id": "icq",
   "name": "ICQ",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-icq",
   "config": {

--- a/recipes/idobata/package.json
+++ b/recipes/idobata/package.json
@@ -1,7 +1,7 @@
 {
   "id": "idobata",
   "name": "Idobata",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://idobata.io",

--- a/recipes/infomaniak-calendar/package.json
+++ b/recipes/infomaniak-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "infomaniak-calendar",
   "name": "Infomaniak Calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://calendar.infomaniak.com"

--- a/recipes/infomaniak-kdrive/package.json
+++ b/recipes/infomaniak-kdrive/package.json
@@ -1,7 +1,7 @@
 {
   "id": "infomaniak-kdrive",
   "name": "Infomaniak KDrive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://kdrive.infomaniak.com/"

--- a/recipes/infomaniak-mail/package.json
+++ b/recipes/infomaniak-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "infomaniak-mail",
   "name": "Infomaniak Mail",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.infomaniak.com/"

--- a/recipes/inoreader/package.json
+++ b/recipes/inoreader/package.json
@@ -1,7 +1,7 @@
 {
   "id": "inoreader",
   "name": "Inoreader",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/annagrram/recipe-inoreader",
   "config": {

--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",

--- a/recipes/intercom/package.json
+++ b/recipes/intercom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "intercom",
   "name": "Intercom",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.intercom.io/",

--- a/recipes/invoice-ninja/package.json
+++ b/recipes/invoice-ninja/package.json
@@ -1,7 +1,7 @@
 {
   "id": "invoice-ninja",
   "name": "Invoice Ninja",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://invoicing.co/#/"

--- a/recipes/irccloud/package.json
+++ b/recipes/irccloud/package.json
@@ -1,7 +1,7 @@
 {
   "id": "irccloud",
   "name": "IRCCloud",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/albertomurillo/recipe-irccloud",
   "config": {

--- a/recipes/iris-messenger/package.json
+++ b/recipes/iris-messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "iris-messenger",
   "name": "Iris Messenger",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://iris.to"

--- a/recipes/jira/package.json
+++ b/recipes/jira/package.json
@@ -1,7 +1,7 @@
 {
   "id": "jira",
   "name": "Jira",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.atlassian.net",

--- a/recipes/jitsi/package.json
+++ b/recipes/jitsi/package.json
@@ -1,7 +1,7 @@
 {
   "id": "jitsi",
   "name": "Jitsi Meet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/sampathBlam/ferdi-jitsi",
   "config": {

--- a/recipes/jollor/package.json
+++ b/recipes/jollor/package.json
@@ -1,7 +1,7 @@
 {
   "id": "jollor",
   "name": "jollor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://jollor.com",

--- a/recipes/kaizala/package.json
+++ b/recipes/kaizala/package.json
@@ -1,7 +1,7 @@
 {
   "id": "kaizala",
   "name": "Microsoft Kaizala",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-microsoft-kaizala",
   "config": {

--- a/recipes/keepervault/package.json
+++ b/recipes/keepervault/package.json
@@ -1,7 +1,7 @@
 {
   "id": "keepervault",
   "name": "Keeper Vault",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://keepersecurity.eu/vault/#"

--- a/recipes/keybase.io/package.json
+++ b/recipes/keybase.io/package.json
@@ -1,7 +1,7 @@
 {
   "id": "keybase.io",
   "name": "Keybase",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://keybase.io/login",

--- a/recipes/kimaicloud/package.json
+++ b/recipes/kimaicloud/package.json
@@ -1,7 +1,7 @@
 {
   "id": "kimaicloud",
   "name": "Kimai Cloud",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "repository": "https://github.com/kimai-cloud/recipe-kimaicloud",
   "config": {

--- a/recipes/kiwiirc/package.json
+++ b/recipes/kiwiirc/package.json
@@ -1,7 +1,7 @@
 {
   "id": "kiwiirc",
   "name": "KiwiIRC",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://kiwiirc.com/nextclient/",

--- a/recipes/lark/package.json
+++ b/recipes/lark/package.json
@@ -1,7 +1,7 @@
 {
   "id": "lark",
   "name": "Lark",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.larksuite.com/messenger/",

--- a/recipes/lastpass/package.json
+++ b/recipes/lastpass/package.json
@@ -1,7 +1,7 @@
 {
   "id": "lastpass",
   "name": "LastPass",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://lastpass.com/?ac=1&lpnorefresh=1",

--- a/recipes/lemmy/package.json
+++ b/recipes/lemmy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "lemmy",
   "name": "Lemmy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [],
   "config": {

--- a/recipes/linear/package.json
+++ b/recipes/linear/package.json
@@ -1,7 +1,7 @@
 {
   "id": "linear",
   "name": "Linear",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://linear.app"

--- a/recipes/lineworks/package.json
+++ b/recipes/lineworks/package.json
@@ -1,7 +1,7 @@
 {
   "id": "lineworks",
   "name": "Line Works",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "hasIndirectMessages": true,

--- a/recipes/linkedin/package.json
+++ b/recipes/linkedin/package.json
@@ -1,7 +1,7 @@
 {
   "id": "linkedin",
   "name": "LinkedIn",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.linkedin.com/messaging"

--- a/recipes/localazy/package.json
+++ b/recipes/localazy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "localazy",
   "name": "Localazy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://localazy.com/my/dashboard"

--- a/recipes/magic-level/package.json
+++ b/recipes/magic-level/package.json
@@ -1,7 +1,7 @@
 {
   "id": "magic-level",
   "name": "Magic Level",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://magiclevel.ml"

--- a/recipes/mailbox.org/package.json
+++ b/recipes/mailbox.org/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mailbox.org",
   "name": "Mailbox.org",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://office.mailbox.org/appsuite/#!!&app=io.ox/portal"

--- a/recipes/mailfence/package.json
+++ b/recipes/mailfence/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mailfence",
   "name": "Mailfence",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": "https://github.com/hafiz-muhammad/ferdium-recipes",
   "config": {

--- a/recipes/mastodeck/package.json
+++ b/recipes/mastodeck/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mastodeck",
   "name": "Mastodeck",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mastodeck.com"

--- a/recipes/mastodon/package.json
+++ b/recipes/mastodon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Mastodon",
   "id": "mastodon",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mastodon.social",

--- a/recipes/mattermost/package.json
+++ b/recipes/mattermost/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mattermost",
   "name": "Mattermost",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/medium/package.json
+++ b/recipes/medium/package.json
@@ -1,7 +1,7 @@
 {
   "id": "medium",
   "name": "Medium",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://medium.com"

--- a/recipes/meetup/package.json
+++ b/recipes/meetup/package.json
@@ -1,7 +1,7 @@
 {
   "id": "meetup",
   "name": "Meetup",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://meetup.com",

--- a/recipes/memos/package.json
+++ b/recipes/memos/package.json
@@ -1,7 +1,7 @@
 {
   "id": "memos",
   "name": "memos",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",

--- a/recipes/meta-business-suite/package.json
+++ b/recipes/meta-business-suite/package.json
@@ -1,7 +1,7 @@
 {
   "id": "meta-business-suite",
   "name": "Meta Business Suite",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://business.facebook.com"

--- a/recipes/mewe/package.json
+++ b/recipes/mewe/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mewe",
   "name": "MeWe",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mewe.com/chat",

--- a/recipes/miro/package.json
+++ b/recipes/miro/package.json
@@ -1,7 +1,7 @@
 {
   "id": "miro",
   "name": "Miro",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://miro.com/app/dashboard/"

--- a/recipes/mirotalk-bro/package.json
+++ b/recipes/mirotalk-bro/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mirotalk-bro",
   "name": "MiroTalk Live Broadcast",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bro.mirotalk.com",

--- a/recipes/mirotalk-c2c/package.json
+++ b/recipes/mirotalk-c2c/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mirotalk-c2c",
   "name": "MiroTalk C2C",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://c2c.mirotalk.com",

--- a/recipes/mirotalk-p2p/package.json
+++ b/recipes/mirotalk-p2p/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mirotalk-p2p",
   "name": "MiroTalk P2P",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://p2p.mirotalk.com",

--- a/recipes/mirotalk-sfu/package.json
+++ b/recipes/mirotalk-sfu/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mirotalk-sfu",
   "name": "MiroTalk SFU",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://sfu.mirotalk.com",

--- a/recipes/mirotalk-webrtc/package.json
+++ b/recipes/mirotalk-webrtc/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mirotalk-webrtc",
   "name": "MiroTalk WebRTC",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://webrtc.mirotalk.com",

--- a/recipes/misskey/package.json
+++ b/recipes/misskey/package.json
@@ -1,7 +1,7 @@
 {
   "id": "misskey",
   "name": "Misskey",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/sharkpp/franz-recipe-misskey",
   "config": {

--- a/recipes/monday/package.json
+++ b/recipes/monday/package.json
@@ -1,7 +1,7 @@
 {
   "id": "monday",
   "name": "Monday",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.monday.com",

--- a/recipes/monicahq/package.json
+++ b/recipes/monicahq/package.json
@@ -1,7 +1,7 @@
 {
   "id": "monicahq",
   "name": "Monica HQ",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/jkbecker/recipe-monica",
   "config": {

--- a/recipes/moodle/package.json
+++ b/recipes/moodle/package.json
@@ -1,7 +1,7 @@
 {
   "id": "moodle",
   "name": "Moodle",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/ms-planner/package.json
+++ b/recipes/ms-planner/package.json
@@ -5,7 +5,7 @@
     "office",
     "tasks"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://tasks.office.com/",

--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "msteams",
   "name": "Microsoft Teams",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "aliases": [
     "teamsChat"

--- a/recipes/mstodo/package.json
+++ b/recipes/mstodo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mstodo",
   "name": "Microsoft To Do",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://to-do.live.com/tasks/",

--- a/recipes/mysms/package.json
+++ b/recipes/mysms/package.json
@@ -1,7 +1,7 @@
 {
   "id": "mysms",
   "name": "MySMS",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.mysms.com"

--- a/recipes/netatmo-energy/package.json
+++ b/recipes/netatmo-energy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "netatmo-energy",
   "name": "Netatmo Energy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/rctneil/franz-recipe-netatmo-energy",
   "config": {

--- a/recipes/netlify/package.json
+++ b/recipes/netlify/package.json
@@ -1,7 +1,7 @@
 {
   "id": "netlify",
   "name": "Netlify",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.netlify.com",

--- a/recipes/nextcloud-calendar/package.json
+++ b/recipes/nextcloud-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-calendar",
   "name": "Nextcloud Calendar",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-calendar/",
   "config": {

--- a/recipes/nextcloud-carnet/package.json
+++ b/recipes/nextcloud-carnet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-carnet",
   "name": "Carnet (Nextcloud)",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-carnet/",
   "config": {

--- a/recipes/nextcloud-cospend/package.json
+++ b/recipes/nextcloud-cospend/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-cospend",
   "name": "Nextcloud Cospend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-cospend/",
   "config": {

--- a/recipes/nextcloud-deck/package.json
+++ b/recipes/nextcloud-deck/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-deck",
   "name": "Nextcloud Deck",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": "https://github.com/mindcombatant/ferdium-recipes/tree/master/recipes/nextcloud-deck/",
   "config": {

--- a/recipes/nextcloud-news/package.json
+++ b/recipes/nextcloud-news/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-news",
   "name": "Nextcloud News",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-news/",
   "config": {

--- a/recipes/nextcloud-talk/package.json
+++ b/recipes/nextcloud-talk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-talk",
   "name": "Nextcloud Talk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-tasks/",
   "config": {

--- a/recipes/nextcloud-tasks/package.json
+++ b/recipes/nextcloud-tasks/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-tasks",
   "name": "Nextcloud Tasks",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/csolisr/ferdium-recipes/tree/master/recipes/nextcloud-tasks/",
   "config": {

--- a/recipes/nextcloud/package.json
+++ b/recipes/nextcloud/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud",
   "name": "Nextcloud",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/nextdoor/package.json
+++ b/recipes/nextdoor/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextdoor",
   "name": "Nextdoor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://nextdoor.co.uk/inbox/"

--- a/recipes/noisli/package.json
+++ b/recipes/noisli/package.json
@@ -1,7 +1,7 @@
 {
   "id": "noisli",
   "name": "Noisli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.noisli.com/login"

--- a/recipes/nomadlist/package.json
+++ b/recipes/nomadlist/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nomadlist",
   "name": "NomadList",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://nomadlist.com/chat",

--- a/recipes/notion-calendar/package.json
+++ b/recipes/notion-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "notion-calendar",
   "name": "Notion Calendar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://calendar.notion.so/",

--- a/recipes/notion/package.json
+++ b/recipes/notion/package.json
@@ -1,7 +1,7 @@
 {
   "id": "notion",
   "name": "Notion",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/TanZng/ferdi-notion",
   "config": {

--- a/recipes/ntfy/package.json
+++ b/recipes/ntfy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "ntfy",
   "name": "ntfy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [
     "Notify"

--- a/recipes/odoo/package.json
+++ b/recipes/odoo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "odoo",
   "name": "Odoo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.odoo.com/web/login",

--- a/recipes/odysee/package.json
+++ b/recipes/odysee/package.json
@@ -1,7 +1,7 @@
 {
   "id": "odysee",
   "name": "Odysee",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": "https://github.com/hafiz-muhammad/ferdium-recipes",
   "config": {

--- a/recipes/office365-owa/package.json
+++ b/recipes/office365-owa/package.json
@@ -1,7 +1,7 @@
 {
   "id": "office365-owa",
   "name": "Office 365 Outlook",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "aliases": [
     "live.com",

--- a/recipes/onenote/package.json
+++ b/recipes/onenote/package.json
@@ -1,7 +1,7 @@
 {
   "id": "onenote",
   "name": "OneNote",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://onenote.com"

--- a/recipes/online-go/package.json
+++ b/recipes/online-go/package.json
@@ -1,7 +1,7 @@
 {
   "id": "online-go",
   "name": "Online Go",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "aliases": [
     "OGS"

--- a/recipes/onmail/package.json
+++ b/recipes/onmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "onmail",
   "name": "onMail",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.onmail.com"

--- a/recipes/oreilly-learning/package.json
+++ b/recipes/oreilly-learning/package.json
@@ -1,7 +1,7 @@
 {
   "id": "oreilly-learning",
   "name": "O'Reilly Learning",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://learning.oreilly.com/home-new/"

--- a/recipes/outreach/package.json
+++ b/recipes/outreach/package.json
@@ -1,7 +1,7 @@
 {
   "id": "outreach",
   "name": "Outreach",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://accounts.outreach.io/users/sign_in"

--- a/recipes/patreon/package.json
+++ b/recipes/patreon/package.json
@@ -1,7 +1,7 @@
 {
   "id": "patreon",
   "name": "Patreon",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.patreon.com/login"

--- a/recipes/paymo/package.json
+++ b/recipes/paymo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "paymo",
   "name": "Paymo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.paymoapp.com/auth/login"

--- a/recipes/penpot/package.json
+++ b/recipes/penpot/package.json
@@ -1,7 +1,7 @@
 {
   "id": "penpot",
   "name": "Penpot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://design.penpot.app/",

--- a/recipes/perplexity/package.json
+++ b/recipes/perplexity/package.json
@@ -1,7 +1,7 @@
 {
   "id": "perplexity",
   "name": "Perplexity AI",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.perplexity.ai/"

--- a/recipes/pinterest/package.json
+++ b/recipes/pinterest/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pinterest",
   "name": "Pinterest",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pinterest.com"

--- a/recipes/pipefy/package.json
+++ b/recipes/pipefy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pipefy",
   "name": "Pipefy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.pipefy.com/",

--- a/recipes/pivotal-tracker/package.json
+++ b/recipes/pivotal-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pivotal-tracker",
   "name": "pivotal-tracker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.pivotaltracker.com/signin",

--- a/recipes/pixelfed/package.json
+++ b/recipes/pixelfed/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pixelfed",
   "name": "Pixelfed",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pixelfed.social",

--- a/recipes/pixieset/package.json
+++ b/recipes/pixieset/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pixieset",
   "name": "Pixieset",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://accounts.pixieset.com/dashboard/"

--- a/recipes/plan/package.json
+++ b/recipes/plan/package.json
@@ -1,7 +1,7 @@
 {
   "id": "plan",
   "name": "Plan",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://getplan.co/",

--- a/recipes/planitpoker/package.json
+++ b/recipes/planitpoker/package.json
@@ -1,7 +1,7 @@
 {
   "id": "planitpoker",
   "name": "PlanITPoker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.planitpoker.com/board/#/room/{teamId}",

--- a/recipes/plek/package.json
+++ b/recipes/plek/package.json
@@ -1,7 +1,7 @@
 {
   "id": "plek",
   "name": "Plek",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": "https://github.com/jsimonetti/franz-recipe-plek",
   "license": "MIT",
   "config": {

--- a/recipes/pleroma/package.json
+++ b/recipes/pleroma/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pleroma",
   "name": "Pleroma",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/plurk/package.json
+++ b/recipes/plurk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "plurk",
   "name": "Plurk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.plurk.com"

--- a/recipes/pocket/package.json
+++ b/recipes/pocket/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pocket",
   "name": "Pocket",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://getpocket.com/a/queue/list/"

--- a/recipes/pocketcasts/package.json
+++ b/recipes/pocketcasts/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pocketcasts",
   "name": "PocketCasts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://play.pocketcasts.com/user/login"

--- a/recipes/podio/package.json
+++ b/recipes/podio/package.json
@@ -1,7 +1,7 @@
 {
   "id": "podio",
   "name": "Podio",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://podio.com",

--- a/recipes/poe/package.json
+++ b/recipes/poe/package.json
@@ -1,7 +1,7 @@
 {
   "id": "poe",
   "name": "poe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://poe.com/"

--- a/recipes/pomodoro-tracker/package.json
+++ b/recipes/pomodoro-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pomodoro-tracker",
   "name": "Pomodoro Tracker",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pomodoro-tracker.com",

--- a/recipes/portainer/package.json
+++ b/recipes/portainer/package.json
@@ -1,7 +1,7 @@
 {
   "id": "portainer",
   "name": "Portainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "hasHostedOption": true,

--- a/recipes/posteo/package.json
+++ b/recipes/posteo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "posteo",
   "name": "Posteo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [
     "mail",

--- a/recipes/postman/package.json
+++ b/recipes/postman/package.json
@@ -1,7 +1,7 @@
 {
   "id": "postman",
   "name": "Postman",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.postman.co/home"

--- a/recipes/producthunt/package.json
+++ b/recipes/producthunt/package.json
@@ -1,7 +1,7 @@
 {
   "id": "producthunt",
   "name": "Product Hunt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/alexdevero/franz-producthunt-recipe",
   "config": {

--- a/recipes/proton-calendar/package.json
+++ b/recipes/proton-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "proton-calendar",
   "name": "ProtonCalendar",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://calendar.proton.me/"

--- a/recipes/proton-drive/package.json
+++ b/recipes/proton-drive/package.json
@@ -1,7 +1,7 @@
 {
   "id": "proton-drive",
   "name": "Proton Drive",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://drive.proton.me"

--- a/recipes/proton-mail/package.json
+++ b/recipes/proton-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "proton-mail",
   "name": "Proton Mail",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.proton.me/login"

--- a/recipes/proton-pass/package.json
+++ b/recipes/proton-pass/package.json
@@ -1,7 +1,7 @@
 {
   "id": "proton-pass",
   "name": "Proton Pass",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pass.proton.me/"

--- a/recipes/protonet/package.json
+++ b/recipes/protonet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "protonet",
   "name": "protonet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamID}.protonet.info",

--- a/recipes/pulse-sms/package.json
+++ b/recipes/pulse-sms/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pulse-sms",
   "name": "PulseSMS",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://pulsesms.app",

--- a/recipes/purelymail/package.json
+++ b/recipes/purelymail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "purelymail",
   "name": "Purelymail",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://inbox.purelymail.com",

--- a/recipes/pushbullet/package.json
+++ b/recipes/pushbullet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pushbullet",
   "name": "Pushbullet",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.pushbullet.com/"

--- a/recipes/pushover/package.json
+++ b/recipes/pushover/package.json
@@ -1,7 +1,7 @@
 {
   "id": "pushover",
   "name": "Pushover",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "repository": "https://github.com/jdwhite/franz-recipe-pushover",
   "config": {

--- a/recipes/rainloop/package.json
+++ b/recipes/rainloop/package.json
@@ -1,7 +1,7 @@
 {
   "id": "rainloop",
   "name": "RainLoop",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": "https://github.com/promarcel/franz-recipe-rainloop",
   "license": "MIT",
   "config": {

--- a/recipes/reclaim/package.json
+++ b/recipes/reclaim/package.json
@@ -1,7 +1,7 @@
 {
   "id": "reclaim",
   "name": "Reclaim",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.reclaim.ai/"

--- a/recipes/reddit-chat/package.json
+++ b/recipes/reddit-chat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "reddit-chat",
   "name": "Reddit Chat",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.reddit.com/chat/"

--- a/recipes/reddit/package.json
+++ b/recipes/reddit/package.json
@@ -1,7 +1,7 @@
 {
   "id": "reddit",
   "name": "Reddit",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/ferdium/ferdium-recipes",
   "config": {

--- a/recipes/regex101/package.json
+++ b/recipes/regex101/package.json
@@ -1,7 +1,7 @@
 {
   "id": "regex101",
   "name": "Regex101",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://regex101.com/"

--- a/recipes/revolt/package.json
+++ b/recipes/revolt/package.json
@@ -1,7 +1,7 @@
 {
   "id": "revolt",
   "name": "Revolt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.revolt.chat/"

--- a/recipes/ring-central/package.json
+++ b/recipes/ring-central/package.json
@@ -1,7 +1,7 @@
 {
   "id": "ring-central",
   "name": "RingCentral",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/deadmeu/ferdi-ringcentral",
   "aliases": [

--- a/recipes/riseup/package.json
+++ b/recipes/riseup/package.json
@@ -1,7 +1,7 @@
 {
   "id": "riseup",
   "name": "Riseup.net",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.riseup.net"

--- a/recipes/ritetag/package.json
+++ b/recipes/ritetag/package.json
@@ -1,7 +1,7 @@
 {
   "id": "ritetag",
   "name": "Ritetag",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/alexdevero/franz-ritetag-recipe",
   "config": {

--- a/recipes/rocketchat/package.json
+++ b/recipes/rocketchat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "rocketchat",
   "name": "Rocket.Chat",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.rocket.chat",

--- a/recipes/romeo/package.json
+++ b/recipes/romeo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "romeo",
   "name": "Romeo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "http://romeo.com",

--- a/recipes/roundcube/package.json
+++ b/recipes/roundcube/package.json
@@ -1,7 +1,7 @@
 {
   "id": "roundcube",
   "name": "Roundcube",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/jonathanjuursema/franz-roundcube",
   "config": {

--- a/recipes/schildichat/package.json
+++ b/recipes/schildichat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "schildichat",
   "name": "SchildiChat",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "aliases": [
     "Element",

--- a/recipes/scribens/package.json
+++ b/recipes/scribens/package.json
@@ -1,7 +1,7 @@
 {
   "id": "scribens",
   "name": "Scribens",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://scribens.{teamId}",

--- a/recipes/scrumpy/package.json
+++ b/recipes/scrumpy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "scrumpy",
   "name": "Scrumpy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/scrumpy/franz-recipe-scrumpy",
   "config": {

--- a/recipes/sendtask/package.json
+++ b/recipes/sendtask/package.json
@@ -1,7 +1,7 @@
 {
   "id": "sendtask",
   "name": "Sendtask",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": "https://github.com/patrickdaniel/sendtask-franz",
   "license": "MIT",
   "config": {

--- a/recipes/simplelogin/package.json
+++ b/recipes/simplelogin/package.json
@@ -1,7 +1,7 @@
 {
   "id": "simplelogin",
   "name": "SimpleLogin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.simplelogin.io/"

--- a/recipes/simplenote/package.json
+++ b/recipes/simplenote/package.json
@@ -1,7 +1,7 @@
 {
   "id": "simplenote",
   "name": "Simplenote",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.simplenote.com/"

--- a/recipes/skiff-mail/package.json
+++ b/recipes/skiff-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skiff-mail",
   "name": "Skiff Mail",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.skiff.com/mail/inbox"

--- a/recipes/skype/package.json
+++ b/recipes/skype/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skype",
   "name": "Skype",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.skype.com/",

--- a/recipes/slack/package.json
+++ b/recipes/slack/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slack",
   "name": "Slack",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.slack.com",

--- a/recipes/slite/package.json
+++ b/recipes/slite/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slite",
   "name": "Slite",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.slite.com",

--- a/recipes/slowly/package.json
+++ b/recipes/slowly/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slowly",
   "name": "Slowly",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/BerakaStudio/franz-slowly",
   "config": {

--- a/recipes/smartsheet/package.json
+++ b/recipes/smartsheet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "smartsheet",
   "name": "SmartSheet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.smartsheet.com"

--- a/recipes/snapchat/package.json
+++ b/recipes/snapchat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "snapchat",
   "name": "Snapchat",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.snapchat.com/"

--- a/recipes/snapdrop/package.json
+++ b/recipes/snapdrop/package.json
@@ -1,7 +1,7 @@
 {
   "id": "snapdrop",
   "name": "Snapdrop",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "http://snapdrop.net/",

--- a/recipes/sococo/package.json
+++ b/recipes/sococo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "sococo",
   "name": "Sococo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/klcodanr/recipe-sococo",
   "config": {

--- a/recipes/sogo/package.json
+++ b/recipes/sogo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "sogo",
   "name": "SOGo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true,

--- a/recipes/stackexchange/package.json
+++ b/recipes/stackexchange/package.json
@@ -1,7 +1,7 @@
 {
   "id": "stackexchange",
   "name": "StackExchange",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://stackexchange.com/"

--- a/recipes/stackoverflow-chat/package.json
+++ b/recipes/stackoverflow-chat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "stackoverflow-chat",
   "name": "Stack Overflow Chat",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://chat.stackoverflow.com/",

--- a/recipes/stackoverflow/package.json
+++ b/recipes/stackoverflow/package.json
@@ -1,7 +1,7 @@
 {
   "id": "stackoverflow",
   "name": "Stack Overflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "repository": "https://github.com/christianascone/franz-recipe-stackoverflow",
   "config": {

--- a/recipes/standardnotes/package.json
+++ b/recipes/standardnotes/package.json
@@ -1,7 +1,7 @@
 {
   "id": "standardnotes",
   "name": "StandardNotes",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "repository": "https://github.com/vantezzen/franz-recipe-standardnotes",
   "config": {

--- a/recipes/steamchat/package.json
+++ b/recipes/steamchat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "steamchat",
   "name": "SteamChat",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://steamcommunity.com/chat",

--- a/recipes/strava/package.json
+++ b/recipes/strava/package.json
@@ -1,7 +1,7 @@
 {
   "id": "strava",
   "name": "Strava",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.strava.com/"

--- a/recipes/stride/package.json
+++ b/recipes/stride/package.json
@@ -1,7 +1,7 @@
 {
   "id": "stride",
   "name": "Stride",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.stride.com",

--- a/recipes/superhuman/package.json
+++ b/recipes/superhuman/package.json
@@ -1,7 +1,7 @@
 {
   "id": "superhuman",
   "name": "Superhuman",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/CrystalLarsh/franz-superhuman-recipe",
   "config": {

--- a/recipes/superlist/package.json
+++ b/recipes/superlist/package.json
@@ -1,7 +1,7 @@
 {
   "id": "superlist",
   "name": "Superlist",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.superlist.com",

--- a/recipes/sympatia/package.json
+++ b/recipes/sympatia/package.json
@@ -1,7 +1,7 @@
 {
   "id": "sympatia",
   "name": "Sympatia",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://sympatia.onet.pl/"

--- a/recipes/sync/package.json
+++ b/recipes/sync/package.json
@@ -1,7 +1,7 @@
 {
   "id": "sync",
   "name": "Sync",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://cp.sync.com/files/"

--- a/recipes/tawk/package.json
+++ b/recipes/tawk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tawk",
   "name": "Tawk.to",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://dashboard.tawk.to/",

--- a/recipes/tchap/package.json
+++ b/recipes/tchap/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tchap",
   "name": "Tchap",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "repository": "https://github.com/Sykursen/recipe-tchap/",
   "config": {

--- a/recipes/teamleader/package.json
+++ b/recipes/teamleader/package.json
@@ -1,7 +1,7 @@
 {
   "id": "teamleader",
   "name": "teamleader",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.teamleader.eu/?gotologin",

--- a/recipes/teamweek/package.json
+++ b/recipes/teamweek/package.json
@@ -1,7 +1,7 @@
 {
   "id": "teamweek",
   "name": "Teamweek",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "repository": "https://github.com/claudiupelmus/recipe-teamweek",
   "config": {

--- a/recipes/teamwork-projects/package.json
+++ b/recipes/teamwork-projects/package.json
@@ -1,7 +1,7 @@
 {
   "id": "teamwork-projects",
   "name": "Teamwork Projects",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.teamwork.com/",

--- a/recipes/telegram/package.json
+++ b/recipes/telegram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "telegram",
   "name": "Telegram",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.telegram.org",

--- a/recipes/temp-mail/package.json
+++ b/recipes/temp-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "temp-mail",
   "name": "Temp Mail",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://temp-mail.org/"

--- a/recipes/thelounge/package.json
+++ b/recipes/thelounge/package.json
@@ -1,7 +1,7 @@
 {
   "id": "thelounge",
   "name": "The Lounge",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true,

--- a/recipes/threads/package.json
+++ b/recipes/threads/package.json
@@ -1,7 +1,7 @@
 {
   "id": "threads",
   "name": "Threads",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://threads.net/",

--- a/recipes/threema/package.json
+++ b/recipes/threema/package.json
@@ -1,7 +1,7 @@
 {
   "id": "threema",
   "name": "Threema",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/Arany/franz-recipe-threema",
   "config": {

--- a/recipes/tick/package.json
+++ b/recipes/tick/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tick",
   "name": "tick",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "http://app.tickspot.com/"

--- a/recipes/tiktok/package.json
+++ b/recipes/tiktok/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tiktok",
   "name": "Tiktok",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://tiktok.com"

--- a/recipes/tinder/package.json
+++ b/recipes/tinder/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tinder",
   "name": "Tinder",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://tinder.com"

--- a/recipes/tixio/package.json
+++ b/recipes/tixio/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tixio",
   "name": "Tixio",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "repository": "https://github.com/hmcclungiii/franz-recipe-tixio",
   "config": {

--- a/recipes/todoist/package.json
+++ b/recipes/todoist/package.json
@@ -1,7 +1,7 @@
 {
   "id": "todoist",
   "name": "Todoist",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-todoist",
   "config": {

--- a/recipes/toggl/package.json
+++ b/recipes/toggl/package.json
@@ -1,7 +1,7 @@
 {
   "id": "toggl",
   "name": "Toggl",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.toggl.com/app/timer",

--- a/recipes/traccar/package.json
+++ b/recipes/traccar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "traccar",
   "name": "Traccar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "hasHostedOption": true,

--- a/recipes/trakt/package.json
+++ b/recipes/trakt/package.json
@@ -1,7 +1,7 @@
 {
   "id": "trakt",
   "name": "Trakt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://trakt.tv"

--- a/recipes/trello/package.json
+++ b/recipes/trello/package.json
@@ -1,7 +1,7 @@
 {
   "id": "trello",
   "name": "Trello",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://trello.com/"

--- a/recipes/tt-rss/package.json
+++ b/recipes/tt-rss/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tt-rss",
   "name": "Tiny Tiny RSS",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true

--- a/recipes/tutanota/package.json
+++ b/recipes/tutanota/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tutanota",
   "name": "Tuta Mail",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "aliases": [
     "Tutanota"

--- a/recipes/tweetdeck/package.json
+++ b/recipes/tweetdeck/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tweetdeck",
   "name": "Tweetdeck",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://tweetdeck.twitter.com/",

--- a/recipes/twist/package.json
+++ b/recipes/twist/package.json
@@ -1,7 +1,7 @@
 {
   "id": "twist",
   "name": "Twist",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://twistapp.com/login",

--- a/recipes/twitch/package.json
+++ b/recipes/twitch/package.json
@@ -1,7 +1,7 @@
 {
   "id": "twitch",
   "name": "Twitch",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.twitch.tv/{teamId}/chat",

--- a/recipes/twitter-dm/package.json
+++ b/recipes/twitter-dm/package.json
@@ -1,7 +1,7 @@
 {
   "id": "twitter-dm",
   "name": "Twitter DM",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mobile.twitter.com/messages",

--- a/recipes/twitter/package.json
+++ b/recipes/twitter/package.json
@@ -1,7 +1,7 @@
 {
   "id": "twitter",
   "name": "X",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "aliases": [
     "Twitter"

--- a/recipes/udemy/package.json
+++ b/recipes/udemy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "udemy",
   "name": "Udemy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/gaspergrom/Franz-services/tree/master/udemy",
   "config": {

--- a/recipes/unraid/package.json
+++ b/recipes/unraid/package.json
@@ -1,7 +1,7 @@
 {
   "id": "unraid",
   "name": "Unraid",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/rctneil/franz-recipe-unraid",
   "config": {

--- a/recipes/vk/package.json
+++ b/recipes/vk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "vk",
   "name": "VK",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-vk",
   "config": {

--- a/recipes/voxer/package.json
+++ b/recipes/voxer/package.json
@@ -1,7 +1,7 @@
 {
   "id": "voxer",
   "name": "Voxer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.voxer.com",

--- a/recipes/wakapi/package.json
+++ b/recipes/wakapi/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wakapi",
   "name": "Wakapi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://wakapi.dev",

--- a/recipes/wakatime/package.json
+++ b/recipes/wakatime/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wakatime",
   "name": "Wakatime",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://wakatime.com/login"

--- a/recipes/webex-teams/package.json
+++ b/recipes/webex-teams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "webex-teams",
   "name": "Webex Teams",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.webex.com",

--- a/recipes/wechat/package.json
+++ b/recipes/wechat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wechat",
   "name": "WeChat",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/koma-private/recipe-wechat",
   "config": {

--- a/recipes/weekplan/package.json
+++ b/recipes/weekplan/package.json
@@ -1,7 +1,7 @@
 {
   "id": "weekplan",
   "name": "Weekplan",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/minipada/recipe-weekplan",
   "config": {

--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whereby/package.json
+++ b/recipes/whereby/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whereby",
   "name": "Whereby",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://whereby.com/{teamId}",

--- a/recipes/whimsical/package.json
+++ b/recipes/whimsical/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whimsical",
   "name": "Whimsical",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://whimsical.com/"

--- a/recipes/wikipedia/package.json
+++ b/recipes/wikipedia/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wikipedia",
   "name": "Wikipedia",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.wikipedia.org/",

--- a/recipes/wire/package.json
+++ b/recipes/wire/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wire",
   "name": "Wire",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.wire.com/",

--- a/recipes/withspectrum/package.json
+++ b/recipes/withspectrum/package.json
@@ -1,7 +1,7 @@
 {
   "id": "withspectrum",
   "name": "Spectrum",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://spectrum.chat"

--- a/recipes/workflowy/package.json
+++ b/recipes/workflowy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "workflowy",
   "name": "WorkFlowy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://workflowy.com"

--- a/recipes/workplace/package.json
+++ b/recipes/workplace/package.json
@@ -1,7 +1,7 @@
 {
   "id": "workplace",
   "name": "Workplace",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.workplace.com/chat",

--- a/recipes/wrike/package.json
+++ b/recipes/wrike/package.json
@@ -1,7 +1,7 @@
 {
   "id": "wrike",
   "name": "Wrike",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/koma-private/recipe-wrike",
   "config": {

--- a/recipes/xing/package.json
+++ b/recipes/xing/package.json
@@ -1,7 +1,7 @@
 {
   "id": "xing",
   "name": "XING",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.xing.com/messenger/global"

--- a/recipes/xmpp/package.json
+++ b/recipes/xmpp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "xmpp",
   "name": "XMPP",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "repository": "https://github.com/Aman9das/ferdi-xmpp-recipe",
   "config": {

--- a/recipes/yahoo-mail/package.json
+++ b/recipes/yahoo-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "yahoo-mail",
   "name": "Yahoo Mail",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.yahoo.com",

--- a/recipes/yammer/package.json
+++ b/recipes/yammer/package.json
@@ -1,7 +1,7 @@
 {
   "id": "yammer",
   "name": "Yammer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.yammer.com/login",

--- a/recipes/yandex-mail/package.json
+++ b/recipes/yandex-mail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "yandex-mail",
   "name": "Yandex Mail",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.yandex.ru"

--- a/recipes/youtrack/package.json
+++ b/recipes/youtrack/package.json
@@ -1,7 +1,7 @@
 {
   "id": "youtrack",
   "name": "YouTrack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.myjetbrains.com/youtrack/",

--- a/recipes/youtube/package.json
+++ b/recipes/youtube/package.json
@@ -1,7 +1,7 @@
 {
   "id": "youtube",
   "name": "YouTube",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://youtube.com/"

--- a/recipes/youtubemusic/package.json
+++ b/recipes/youtubemusic/package.json
@@ -1,7 +1,7 @@
 {
   "id": "youtubemusic",
   "name": "YouTube Music",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://music.youtube.com/"

--- a/recipes/zalo/package.json
+++ b/recipes/zalo/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zalo",
   "name": "Zalo",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://chat.zalo.me/",

--- a/recipes/zammad/package.json
+++ b/recipes/zammad/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zammad",
   "name": "Zammad",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/zendesk/package.json
+++ b/recipes/zendesk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zendesk",
   "name": "Zendesk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.zendesk.com/agent",

--- a/recipes/zenhub/package.json
+++ b/recipes/zenhub/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zenhub",
   "name": "ZenHub",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "repository": "https://github.com/mordaroso/recipe-franz-zenhub",
   "config": {

--- a/recipes/zeplin/package.json
+++ b/recipes/zeplin/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zeplin",
   "name": "Zeplin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://app.zeplin.io/login"

--- a/recipes/zimbra/package.json
+++ b/recipes/zimbra/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zimbra",
   "name": "Zimbra",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/zoho-projects/package.json
+++ b/recipes/zoho-projects/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoho-projects",
   "name": "Zoho Projects",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://projects.zoho.eu/"

--- a/recipes/zoho/package.json
+++ b/recipes/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoho",
   "name": "Zoho Mail",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.zoho.com/mail/login.html",

--- a/recipes/zoom/package.json
+++ b/recipes/zoom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoom",
   "name": "Zoom",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://zoom.us/join",

--- a/recipes/zulip/package.json
+++ b/recipes/zulip/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zulip",
   "name": "Zulip",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

After the merge of this https://github.com/ferdium/ferdium-recipes/pull/537, users need to reload their recipes so that they see their SVG removed from local AppData.

This PR updates all recipes by bumping their minor version.
