### PR TITLE
Handle case correctly where the 'icon.svg' file isn't present

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -84,7 +84,7 @@ const compress = (src, dest) =>
     // Check that each mandatory file exists
     for (const file of mandatoryFiles) {
       const filePath = path.join(recipeSrc, file);
-      if (!fs.pathExistsSync(filePath)) {
+      if (!fs.existsSync(filePath)) {
         console.log(
           `⚠️ Couldn't package "${recipe}": Folder doesn't contain a "${file}".`,
         );
@@ -97,19 +97,21 @@ const compress = (src, dest) =>
 
     // Check icons sizes
     const svgIcon = path.join(recipeSrc, 'icon.svg');
-    const svgSize = sizeOf(svgIcon);
-    const svgHasRightSize = svgSize.width === svgSize.height;
-    if (!svgHasRightSize) {
-      console.log(
-        `⚠️ Couldn't package "${recipe}": Recipe SVG icon isn't a square`,
-      );
-      unsuccessful += 1;
-      continue;
+    if (fs.existsSync(svgIcon)) {
+      const svgSize = sizeOf(svgIcon);
+      const svgHasRightSize = svgSize.width === svgSize.height;
+      if (!svgHasRightSize) {
+        console.log(
+          `⚠️ Couldn't package "${recipe}": Recipe SVG icon isn't a square`,
+        );
+        unsuccessful += 1;
+        continue;
+      }
     }
 
     // Check that user.js does not exist
     const userJs = path.join(recipeSrc, 'user.js');
-    if (fs.pathExistsSync(userJs)) {
+    if (fs.existsSync(userJs)) {
       console.log(
         `⚠️ Couldn't package "${recipe}": Folder contains a "user.js".`,
       );
@@ -293,14 +295,14 @@ const compress = (src, dest) =>
 
     if (!config.defaultIcon) {
       // Check if icon.svg exists
-      if (!fs.existsSync(path.join(recipeSrc, 'icon.svg'))) {
+      if (!fs.existsSync(svgIcon)) {
         console.log(
           `⚠️ Couldn't package "${recipe}": The recipe doesn't contain a "icon.svg" or "defaultIcon" in package.json`,
         );
         unsuccessful += 1;
       }
 
-      const tempPackage = fs.readJSONSync(
+      const tempPackage = fs.readJsonSync(
         path.join(tempFolder, config.id, 'package.json'),
       );
       tempPackage.defaultIcon = `${repo}${config.id}/icon.svg`;


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

<!-- Describe your changes in detail. -->
1. Minor refactoring to use consistent `fs.existsSync` for files.
2. Also, fixed a bug where, if the `icon.svg` file was missing, the packaging step would error out.