### PR TITLE
Normalize path in pkgJsonRelative before comparing

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -256,7 +256,9 @@ const compress = (src, dest) =>
             result.insertions !== 0 ||
             result.deletions !== 0)
         ) {
-          const pkgJsonRelative = path.relative(repoRoot, packageJson);
+          const pkgJsonRelative = path.normalize(
+            path.relative(repoRoot, packageJson),
+          );
           if (result.files.some(({ file }) => file === pkgJsonRelative)) {
             git.diff(pkgJsonRelative, (_diffErr, diffResult) => {
               if (diffResult && !pkgVersionChangedMatcher.test(diffResult)) {


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change
As explain [in this issue](https://github.com/ferdium/ferdium-app/issues/1778), we cannot validate PR for recipes because `pnpm validate` is still a failure.
Script compare the list of detected change where path are like "recipes/hangoutschat/package.json" and pkgJsonRelative contaning path to package.json with this format "recipes\hangoutschat\package.json".
Of course, it never match.

Change : add path normalization on pkgJsonRelative 
