### PR TITLE
Fix discord going to mobile version on mac

### DIFF
--- a/recipes/discord/index.js
+++ b/recipes/discord/index.js
@@ -5,6 +5,7 @@ module.exports = Ferdium =>
         .replace('(KHTML, like Gecko)', '(KHTML, like Gecko) discord/0.0.250')
         .replace('Electron', 'Discord')
         .replace('Ferdium', 'Discord')
-        .replace('Apple Mac OS X', 'Intel Mac OS X');
+        .replace('Apple Mac OS X', 'Intel Mac OS X')
+        .replace('Apple macOS', 'Intel Mac OS X');
     }
   };

--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discord.com/app",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

For an unknown reason, when Discord sees `Apple macOS` in the user agent, it defaults to the mobile/tablet version of the website instead of the desktop version. Replacing it with the string `Intel Mac OS X` fixes the issue.