### PR TITLE
Fix selector for unread GitHub notifications count

### DIFF
--- a/recipes/github/package.json
+++ b/recipes/github/package.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "GitHub",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://github.com/notifications",

--- a/recipes/github/webview.js
+++ b/recipes/github/webview.js
@@ -11,7 +11,7 @@ module.exports = Ferdium => {
       ?.textContent?.match(/\d+/);
     Ferdium.setBadge(
       Ferdium.safeParseInt(
-        document.querySelector('.filter-list.js-notification-inboxes .count')
+        document.querySelector('li[data-item-id="inbox"] .Counter')
           ?.textContent,
       ) + Ferdium.safeParseInt(newCountMatch ? newCountMatch[0] : 0),
       document.querySelectorAll(


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Because of recent changes in GitHub unread notifications count from the bubble next to "Inbox" was not correctly detected, so the selector was updated to fix this.
