### PR TITLE
Injecting `darkmode.css` for Messenger when appropriate

### DIFF
--- a/recipes/messenger/darkmode.css
+++ b/recipes/messenger/darkmode.css
@@ -1,94 +1,421 @@
 /* Copied from: https://github.com/ducfilan/Dark-mode-Franz-Ferdi */
 
-:root,
-.__fb-light-mode {
-  --card-background: #1e1e1e;
-  --chat-incoming-message-bubble-background-color: #292929;
-  --comment-background: #292929;
-  --comment-footer-background: #333;
-  --card-background-flat: #292929;
-  --disabled-button-background: #373737;
-  --divider: #4d4d4d;
-  --hosted-view-selected-state: #1D2731;
-  --hover-overlay: rgba(255, 255, 255, 0.05);
-  --media-inner-border: rgba(255, 255, 255, 0.1);
-  --messenger-card-background: #1e1e1e;
-  --mwp-message-row-background: #1e1e1e;
-  --overlay-alpha-80: rgba(41, 41, 41, 0.8);
-  --popover-background: #1e1e1e;
-  --primary-icon: #cecece;
-  --primary-text: #cecece;
-  --scroll-thumb: #5d5d5d;
-  --secondary-button-background: #353535;
-  --secondary-icon: #999;
-  --secondary-text: #999;
-  --shadow-1: rgba(0, 0, 0, 0.3);
-  --shadow-2: rgba(0, 0, 0, 0.4);
-  --shadow-5: rgba(0, 0, 0, 0.7);
-  --shadow-8: rgba(0, 0, 0, 1);
-  --shadow-inset: rgba(000, 000, 000, 0.5);
-  --surface-background: #1e1e1e;
-  --wash: #373737;
-  --web-wash: #1e1e1e;
+:root:not(#z) {
+  --bshadow: 0 2px 4px var(--shadow);
+  --t: transparent !important;
+  --avatar: a_radius;
+  --ui-font: "font_name", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, Ubuntu, Cantarell, "Noto Sans", var(--emoji-font),
+    sans-serif;
+  --emoji-font: "font_name", "joypixels", "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
+  --white: #fff;
+  --dark: #1f232a;
+  --darken: #252a33;
+  --darker: #333943;
+  --light: #e9e9e9;
+  --lighter: #a1a1a1;
+  --accent: #7289da;
+  --shadow: rgba(0, 0, 0, 0.145);
+  --yellow: #e5c512;
+  --orange: #df4b16;
+  --red: #dc322f;
+  --magenta: #f33682;
+  --violet: #6c71c4;
+  --blue: #268bd2;
+  --cyan: #2aa198;
+  --green: #859900;
+  --dark-rgb: 31, 35, 42;
+  --darken-rgb: 37, 42, 51;
+  --darker-rgb: 51, 57, 67;
+  --light-rgb: 233, 233, 233;
+  --lighter-rgb: 161, 161, 161;
+  --accent-rgb: 114, 137, 218;
+  --shadow-rgb: 0, 0, 0;
+  --white-rgb: 255, 255, 255;
+  --b6a: var(--darker-rgb);
+  --b38: var(--darker-rgb);
+  --ce3: var(--darker-rgb);
+  --ca6: var(--darker-rgb);
+  --d87: var(--darken-rgb);
+  --f23: var(--darken-rgb);
+  --b3f: var(--dark-rgb);
+  --i1d: var(--light-rgb);
+  --f75: var(--light-rgb);
+  --f52: var(--lighter-rgb);
+  --bb2: var(--darken-rgb);
+  --f23: var(--dark-rgb);
+  --fe0: var(--accent-rgb);
+  --d69: var(--accent-rgb);
+  --c37: var(--accent-rgb);
+  --eca: var(--darken-rgb);
+  --jb7: var(--shadow-rgb);
+  --fa7: var(--darken-rgb);
+  --de5: var(--white-rgb);
 }
-
-html::-webkit-scrollbar {
-  display: none;
-}
-
 ::-webkit-scrollbar {
-  background: var(--popover-background);
+  width: 0.5em;
 }
-
+* {
+  scrollbar-width: thin;
+}
+html {
+  scrollbar-color: var(--accent) rgba(136, 136, 136, 0.082);
+}
+::-webkit-scrollbar {
+  background-color: rgba(136, 136, 136, 0.082) !important;
+}
 ::-webkit-scrollbar-thumb {
-  background: var(--scroll-thumb);
+  background-color: var(--accent) !important;
 }
-
 body {
-  color: var(--primary-text);
+  color: var(--light) !important;
+  background-color: var(--dark) !important;
+}
+body ::placeholder {
+  color: var(--lighter) !important;
+}
+body ::-webkit-input-placeholder {
+  color: var(--lighter) !important;
+}
+body,
+body button,
+body input,
+body textarea {
+  font-family: var(--ui-font) !important;
+}
+body[style*="background: white"] {
+  background-color: var(--dark) !important;
+}
+body[style*="background: white"] svg {
+  fill: var(--lighter) !important;
+}
+body[class*="error"] .top-bar,
+body[class*="404"] .top-bar {
+  color: var(--light) !important;
+  border-color: var(--darker) !important;
+  background-color: var(--darken) !important;
+}
+body[class*="error"] .top-bar .logo,
+body[class*="404"] .top-bar .logo {
+  filter: invert(0.8) !important;
+}
+body[class*="error"] a,
+body[class*="404"] a,
+body[class*="error"] strong,
+body[class*="404"] strong {
+  color: var(--accent) !important;
+}
+body svg[fill="#262626"] {
+  fill: var(--light);
+}
+body svg[fill="#ffffff"] {
+  fill: var(--light);
+}
+body svg[fill="#8e8e8e"] {
+  fill: var(--lighter);
+}
+body svg[fill="#ed4956"] {
+  fill: var(--red);
+}
+body svg[fill="#0095f6"] {
+  fill: var(--blue);
+}
+body svg path {
+  transition: fill-opacity 0.2s ease;
+}
+body svg:hover path {
+  fill-opacity: 0.6;
+}
+body .coreSpriteLoggedOutWordmark,
+body .coreSpriteMobileNavDirect,
+body .coreSpriteTaggedNull {
+  filter: invert(0.8) !important;
+}
+[class*="SpriteDirect"],
+[class*="SpriteFacebook"],
+[class*="SpriteLink"],
+[class*="SpriteMail"],
+[class*="SpriteApp"],
+[class*="Spritez"],
+[class*="SpriteKeyhole"],
+[class*="SpriteFriend_"],
+[class*="SpriteAdd_friend_"],
+[class*="SpriteDropdownArrowGrey"],
+[class*="SpritePagingChevron"],
+[class*="SpriteCamera"],
+[class*="SpriteProfileChannelNullState"],
+[class*="SpriteLocation_"],
+[class*="SpriteInfo__filled__16__grey"],
+[class*="SpriteCircle_add"] {
+  filter: invert(0.8) !important;
+}
+img[src*="44884218_345707102882519_2446069589734326272"] {
+  filter: invert(0.8) !important;
+}
+body ._2Lks6 {
+  color: var(--accent) !important;
+}
+body nav a[href="/"] img,
+[src*="logo.png"] {
+  filter: invert(0.8);
+}
+body .HZ802,
+body .nHGTw {
+  color: var(--white) !important;
+  background-color: var(--accent) !important;
+}
+body .HZ802 .H9zXO::after,
+body .nHGTw .H9zXO::after {
+  background-color: var(--accent) !important;
+}
+.iMofo {
+  box-shadow: 0 4px 16px var(--shadow) !important;
+}
+body .HZ802 [class*="Sprite"] + div > div,
+body .nHGTw [class*="Sprite"] + div > div {
+  color: var(--white) !important;
+}
+body > [role="presentation"],
+body > [role="dialog"] {
+  background: rgba(var(--b3f), 0.8) !important;
+}
+.not-logged-in .N9d2H {
+  display: none !important;
+}
+.not-logged-in [style*="overflow: hidden"] {
+  overflow: unset !important;
+}
+.not-logged-in [style*="overflow: hidden"] > [role="presentation"] {
+  display: none !important;
+}
+body .LFGs8 {
+  color: var(--accent) !important;
+}
+body .yQ0j1 {
+  color: var(--lighter) !important;
+}
+body .M-jxE,
+body .M-jxE > button {
+  background-color: var(--darken) !important;
+}
+body ._4Kbb_ {
+  margin-top: 1rem;
+  color: var(--light) !important;
+  border-color: var(--darker) !important;
+  background-color: var(--darken) !important;
+}
+.hUQXy,
+.hUQXy:visited {
+  color: var(--accent) !important;
+}
+body .jju9v {
+  border: 1px solid var(--darker);
+  color: var(--light) !important;
+  background-color: var(--darken) !important;
+}
+body .hI7cq {
+  color: var(--light) !important;
+}
+body .isgrP > ul {
+  background-color: var(--t) !important;
+}
+body ._7LpC8 a,
+body .rin8p {
+  color: var(--accent) !important;
+}
+body .rb9ad,
+body .-wdIA,
+body .d-Vzv {
+  border-color: var(--darker) !important;
+}
+body .leaflet-container {
+  background-color: var(--darken) !important;
+  box-shadow: 0 1px var(--darker);
+}
+body .leaflet-tile {
+  filter: invert(0.9) hue-rotate(180deg) !important;
+}
+body .leaflet-popup-content-wrapper,
+body .leaflet-popup-tip {
+  background-color: var(--darken) !important;
+  box-shadow: 0 3px 14px var(--shadow);
+}
+body .Sux9m {
+  border-color: #aaa !important;
+  background-color: rgba(238, 238, 238, 0.067) !important;
+  --eca: var(--light-rgb);
+}
+body .Sux9m ::placeholder {
+  color: #eee !important;
+}
+body .Sux9m ::-webkit-input-placeholder {
+  color: #eee !important;
+}
+body .Sux9m + div [class*="glyphsSpriteDirect_"] {
+  filter: invert(0.3) !important;
+}
+body .tCibT {
+  border: 1px solid var(--darker) !important;
+  box-shadow: var(--bshadow) !important;
+}
+.R8iOs {
+  border: 1px solid var(--darker) !important;
+  color: var(--light) !important;
+  background-color: var(--dark) !important;
+}
+.R8iOs > * {
+  color: inherit;
+}
+[role="button"] + span[class=""] > div[class],
+.G_hoz {
+  background-color: var(--darker) !important;
+}
+body header + div + div.GZkEI li[style] > div > div > [role],
+body article + div + div.GZkEI li[style] > div > div > [role] {
+  --d87: var(--dark-rgb);
+}
+body .WidCF,
+body .HaS-3 {
+  border-right: 1px solid var(--darker);
+  background-size: 200% 200% !important;
+  background: linear-gradient(
+    115deg,
+    var(--dark) 40%,
+    var(--darken),
+    var(--dark) 60%
+  );
+  animation: Loader 2.5s ease infinite !important;
+  background-color: var(--darken) !important;
+}
+body > [role="dialog"] > [role="dialog"] > [role="dialog"] {
+  border: 1px solid var(--darker) !important;
+  box-shadow: 0 0px 16px var(--darken);
+}
+body [role="dialog"] > article > header {
+  overflow-x: hidden !important;
+}
+body [role="dialog"] > article > header + div {
+  --jb7: var(--darken-rgb);
+}
+body > [role="presentation"] > [role="dialog"] > div {
+  border: 1px solid var(--darker) !important;
+}
+body > [role="presentation"] button.aOOlW:not(.SRPMb):hover,
+body > [role="presentation"] button.aOOlW:not(.SRPMb):active {
+  background-color: var(--darken) !important;
+}
+body article > header ~ div .WXPwG .Yi5aA {
+  background-color: var(--white) !important;
+}
+body img + div[style="height: 100%;"],
+body video + div[style="height: 100%;"] {
+  position: unset !important;
+  display: none !important;
+}
+body ._9AhH0 {
+  position: unset !important;
+}
+body .PyenC,
+body .fXIG0 {
+  bottom: 40px !important;
+}
+body .GBPOY {
+  border-radius: 3px;
+  border-color: var(--darker) !important;
+  background-color: var(--darken) !important;
+}
+body .GBPOY a {
+  color: var(--light) !important;
+}
+body .uo5MA,
+body .uo5MA > div:nth-child(1) {
+  box-shadow: var(--bshadow) !important;
+  border: 1px solid var(--darker);
+  background-color: var(--dark) !important;
+}
+body .uo5MA > div:nth-child(2) {
+  background-color: var(--dark) !important;
+}
+body .uo5MA > div:nth-child(3) {
+  border-radius: 0 0 6px 6px;
+}
+body .uo5MA .DPiy6 {
+  background-color: var(--t) !important;
+}
+body .QOqBd {
+  background-color: var(--darker) !important;
+}
+.X3a-9 {
+  background-color: var(--dark) !important;
+}
+body .CMoMH:not(._6FEQj) {
+  background-color: var(--dark) !important;
+}
+body .CMoMH._6FEQj {
+  background-color: var(--darker) !important;
+}
+body .XjicZ {
+  border-top: 1px solid var(--darker);
+  background-color: var(--darken) !important;
+}
+body .XjicZ p {
+  color: var(--light) !important;
+}
+body footer {
+  width: 100% !important;
+  margin: 0 auto !important;
+  max-width: 935px !important;
+  border-top: 1px solid var(--darker) !important;
+}
+.XfvCs {
+  margin-bottom: 30px !important;
+}
+body footer > div::after {
+  content: var(--note);
+  text-align: center;
+  margin-top: 2rem;
+}
+@keyframes Loader {
+  0% {
+    background-position: 33% 0%;
+  }
+  50% {
+    background-position: 68% 100%;
+  }
+  100% {
+    background-position: 33% 0%;
+  }
 }
 
-/* Delivered icon on left*/
-.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.pfnyh3mw.d2edcug0.hpfvmrgz.aovydwv3.p8cu3f6v.kb5gq1qc.taijpn5t.b0upgy8r path,
-.l9j0dhe7.swg4t2nn path,
-.a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 path {
-  fill: var(--primary-text);
+:root:not(#z) {
+  scrollbar-color: var(--accent) transparent;
 }
 
-path[d="M0 36h36V0H0z"] {
-  fill: none !important;
+:root ::-webkit-scrollbar {
+  background-color: transparent !important;
+  width: 0 !important;
+}
+:root ::-webkit-scrollbar-thumb {
+  background-color: var(--accent) !important;
+}
+div.Igw0E.IwRSH.eGOV_._4EzTm._5VUwz.ZUqME ::-webkit-scrollbar,
+div.N9abW::-webkit-scrollbar,
+div.frMpI.-sxBV::-webkit-scrollbar {
+  background-color: transparent !important;
+  width: 0.5em !important;
+}
+div.N9abW::-webkit-scrollbar-thumb,
+div.Igw0E.IwRSH.eGOV_._4EzTm._5VUwz.ZUqME ::-webkit-scrollbar-thumb,
+div.frMpI.-sxBV::-webkit-scrollbar-thumb {
+  background-color: var(--accent) !important;
 }
 
-/* Icons */
-path[d="M18 30c-6.627 0-12-5.372-12-12 0-6.627 5.373-12 12-12 6.628 0 12 5.373 12 12 0 6.628-5.372 12-12 12zm5.294-16.707l-7.296 7.295-3.254-3.252c-.352-.353-.919-.439-1.323-.148a1 1 0 00-.128 1.522l3.998 3.997a1 1 0 001.414 0l8.002-8.001a1 1 0 10-1.413-1.413z"] {
-  fill: var(--secondary-text);
+div.frMpI.-sxBV {
+  padding: 20px 30px 0 20px !important;
 }
 
-.sp_o5t_XtHjhxN_1_5x {
-  filter: invert(.8);
-}
-
-/* App download */
-.oajrlxb2.q2y6ezfg.gcieejh5.bn081pho.humdl8nn.izx4hr6d.rq0escxv.nhd2j8a9.j83agx80.p7hjln8o.kvgmc6g5.cxmmr5t8.oygrvhab.hcukyx3x.jb3vyjys.d1544ag0.qt6c0cv9.tw6a2znq.i1ao9s8h.esuyzwwr.f1sip0of.lzcic4wl.l9j0dhe7.abiwlrkh.p8dawk7l.beltcj47.p86d2i9g.aot14ch1.kzx2olss.cbu4d94t.taijpn5t.ni8dbmo4.stjgntxs.k4urcfbm.tv7at329 {
-  background: var(--popover-background);
-}
-
-.sn0e7ne5 {
-  box-shadow: var(--shadow-5) 0px 0px 2px;
-}
-
-/* Middle header */
-.bafdgad4 {
-  box-shadow: 0 0 4px var(--shadow-5);
-}
-
-/* Pop-up close icon */
-.sp_GOPGoqMu6Pq_1_5x {
-  filter: invert(.8);
-}
-
-/* Feedback icons */
-.sp_BQbKIpOzOAx_1_5x,
-.sp_a51jIvPl6dA_1_5x {
-  filter: invert(.8);
+body footer nav + span::before,
+button.sXUSN:hover {
+  cursor: pointer !important;
 }

--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -127,8 +127,10 @@ module.exports = (Ferdium, settings) => {
     true,
   );
 
-  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  if (
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
     Ferdium.injectCSS(_path.default.join(__dirname, 'darkmode.css'));
   }
-
 };

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -126,4 +126,9 @@ module.exports = (Ferdium, settings) => {
     },
     true,
   );
+
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    Ferdium.injectCSS(_path.default.join(__dirname, 'darkmode.css'));
+  }
+
 };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

This is mostly a proof of concept.

Currently, none of the services display their dark themes even with the system in dark mode, Ferdium in dark mode, and the universal dark mode feature turned on. It's long bothered me that some recipes have `darkmode.css` files but don't seem to be injected anywhere. So I tested out making some changes to `webview.js`, to inject the CSS if it's detected that the system is in dark mode. It seems to work. I am proposing that the previous snippet be added to all recipes if they have a `darkmode.css` file.

To me, it seems this would solve the dark mode issue (assuming we have a functional `darkmode.css` file). But I do wish to be cautious and see what more senior and knowledgeable contributors think before I proceed.