### PR TITLE
Google Calendar Dark Mode updated to v20240912.0.1

### DIFF
--- a/recipes/google-calendar/darkmode.css
+++ b/recipes/google-calendar/darkmode.css
@@ -1,7 +1,7 @@
 /*
 @name           Google Calendar Redesigned (Dark Mode)
 @namespace      Globex Designs, Inc.
-@version        20240706.0.1
+@version        20240912.0.1
 @homepageURL    https://github.com/EvHaus/google-redesigned
 @updateURL      https://raw.githubusercontent.com/EvHaus/google-redesigned/master/css/calendar.user.css
 @license        CC-BY-4.0
@@ -64,12 +64,18 @@
 		}
 
         /* Scroll Bar Hover */
-        ::-webkit-scrollbar-thumb:hover, .mDPmMe::-webkit-scrollbar-thumb:hover,  .WefNYe::-webkit-scrollbar-thumb:hover {
+        ::-webkit-scrollbar-thumb:hover,
+		.mDPmMe::-webkit-scrollbar-thumb:hover,
+		.WefNYe::-webkit-scrollbar-thumb:hover {
+			/* stylelint-disable-next-line color-function-notation */
 			background: hsl(from var(--SCROLLBAR) h s l / 0.8);
 		}
     
         /* Scroll Bar Clicked */
-        ::-webkit-scrollbar-thumb:active, .mDPmMe::-webkit-scrollbar-thumb:active, .WefNYe::-webkit-scrollbar-thumb:active {
+        ::-webkit-scrollbar-thumb:active,
+		.mDPmMe::-webkit-scrollbar-thumb:active,
+		.WefNYe::-webkit-scrollbar-thumb:active {
+            /* stylelint-disable-next-line color-function-notation */
             background: hsl(from var(--SCROLLBAR) h s l / 0.7);
         }
 	
@@ -885,7 +891,9 @@
                 }
 	
 		/* Body */
-		.kma42e {
+		.kma42e,
+        .mR2qle /* 2024-09 Update */
+        {
 			background: var(--GR6) !important;
 			color: var(--GR19) !important
 		}
@@ -949,7 +957,8 @@
 			
 			.vfzv a:link:hover,
 			.vfzv a:link:focus,
-            .vfzv a:visited:hover, 
+            .vfzv a:visited:hover,
+ 
             .vfzv a:visited:focus {
 				color: var(--GR19) !important
 			}
@@ -1152,14 +1161,14 @@
 			.sgEL6b { color: var(--GR15) !important }
 		
 			/* "Yes" button */
-			.qydq8.KKjvXb [data-button-type=actionButton],
-			.qydq8.KKjvXb [data-button-type=menuButton] {
+			.qydq8.KKjvXb [data-button-type="actionButton"],
+			.qydq8.KKjvXb [data-button-type="menuButton"] {
 				background: var(--GR6) !important;
 				border-color: var(--GR10) !important
 			}
 	
-				.qydq8.KKjvXb [data-button-type=actionButton]:hover,
-				.qydq8.KKjvXb [data-button-type=menuButton]:hover {
+				.qydq8.KKjvXb [data-button-type="actionButton"]:hover,
+				.qydq8.KKjvXb [data-button-type="menuButton"]:hover {
 					background: var(--GR8) !important;
 				}
 		
@@ -1283,7 +1292,7 @@
         /* When deleting recurring task > "Delete repeating task" modal */
         
             /* Text */
-            .cC1eCc .VfPpkd-cnG4Wd { color: var(--GR15) !important } 
+            .cC1eCc .VfPpkd-cnG4Wd { color: var(--GR15) !important }
 	
 	/* BOOKABLE APPOINTMENT SCHEDULE POPOVER */
 	

--- a/recipes/google-calendar/package.json
+++ b/recipes/google-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-calendar",
   "name": "Google Calendar",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "license": "MIT",
   "aliases": [
     "google-calendar",


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

This updates Google Calendar's dark mode to version 20240912.0.1 extracted from https://github.com/EvHaus/google-redesigned.

This styling was added in https://github.com/ferdium/ferdium-recipes/pull/575 and requires updates from time to time as Google has a tendency of breaking compatibility.
