### PR TITLE
fix(azure-devops): add support for teamid

### DIFF
--- a/recipes/azure-devops/package.json
+++ b/recipes/azure-devops/package.json
@@ -1,12 +1,14 @@
 {
   "id": "azure-devops",
   "name": "Azure DevOps",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "aliases": [
     "azdo"
   ],
   "config": {
-    "serviceURL": "https://dev.azure.com/"
+    "serviceURL": "https://dev.azure.com/{teamId}",
+    "hasTeamId": true,
+    "urlInputPrefix": "dev.azure.com/"
   }
 }


### PR DESCRIPTION
Due to changes in azure devops' routing, a workspace is required now to be redirected to the correct screen

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Add teamid support for azure-devops recipe, since Microsoft changed something in the routing, and it will always go to the sales page of devops
