### PR TITLE
Update webview.js to fix issue with popup-message notifications (https://github.com/ferdium/ferdium-app/issues/1675)

### DIFF
--- a/recipes/msteams/webview.js
+++ b/recipes/msteams/webview.js
@@ -4,20 +4,15 @@ function _interopRequireDefault(obj) {
 
 const _path = _interopRequireDefault(require('path'));
 
+// Variable to keep previous notification in
+let previousNotification = null;
+
 module.exports = Ferdium => {
   const getMessages = () => {
     let messages = 0;
-
-    const isTeamsV2 = window.location.href.includes('/v2/');
-
-    let badges = document.querySelectorAll(
+    const badges = document.querySelectorAll(
       '.activity-badge.dot-activity-badge .activity-badge',
     );
-
-    if (isTeamsV2) {
-      badges = document.querySelectorAll('.fui-Badge');
-    }
-
     if (badges) {
       Array.prototype.forEach.call(badges, badge => {
         messages += Ferdium.safeParseInt(badge.textContent);
@@ -38,4 +33,30 @@ module.exports = Ferdium => {
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
   Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
+
+  // Function to handle the double notifications
+  Ferdium.onNotify(notification => {
+    // Turn off the need for clicking on the notification, for it to disappear
+    notification.options.requireInteraction = false;
+
+    if (previousNotification === null) {
+      // Handle very first notification
+      previousNotification = notification;
+
+      return notification;
+    }
+
+    // Updating the previous notification variable
+    previousNotification = notification;
+
+    if (
+        previousNotification.title === notification.title
+        && previousNotification.options.body === notification.options.body
+    ) {
+      // The notification is the same as previous one, so we return null to ensure that it will not show
+      return null;
+    }
+
+    return notification;
+  });
 };


### PR DESCRIPTION
#### Description of Change
Bugfix to remove annoying alert-message notifications in msteams addon, which duplicate the push-notifications and have to been closed each on its own by user.

Thanks to @tulexx for his patch.
MR to merge this fix into official receipe for msteams: https://gist.github.com/tulexx/54df51101366b329cbdcc050f9a9037c

discussed in issue https://github.com/ferdium/ferdium-app/issues/1675
