### PR TITLE
franz-custom-website: fix click events when trapLinkClicks is enabled

### DIFF
--- a/recipes/franz-custom-website/package.json
+++ b/recipes/franz-custom-website/package.json
@@ -1,7 +1,7 @@
 {
   "id": "franz-custom-website",
   "name": "Custom Website",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-custom-website",
   "config": {

--- a/recipes/franz-custom-website/webview.js
+++ b/recipes/franz-custom-website/webview.js
@@ -7,6 +7,8 @@ const _path = _interopRequireDefault(require('path'));
 module.exports = (Ferdium, settings) => {
   Ferdium.injectCSS(_path.default.join(__dirname, 'style.css'));
 
+  if (settings.trapLinkClicks === true) return;
+
   // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener(
     'click',
@@ -22,12 +24,7 @@ module.exports = (Ferdium, settings) => {
         if (!Ferdium.isImage(link)) {
           event.preventDefault();
           event.stopPropagation();
-
-          if (settings.trapLinkClicks === true) {
-            window.location.href = url;
-          } else {
-            Ferdium.openNewWindow(url);
-          }
+          Ferdium.openNewWindow(url);
         }
       }
     },


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Fully deactivates messing with `click` events when "Open external URLs in Ferdium" is enabled. Previously Ferdium would eat all click events on `<a href="http://...` and `<button title="http://...` tags, breaking sites that override click events to provide in-page navigation.

Close ferdium/ferdium-app#2028
