### PR TITLE
Update MS Teams serviceURL

### DIFF
--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -1,13 +1,13 @@
 {
   "id": "msteams",
   "name": "Microsoft Teams",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "license": "MIT",
   "aliases": [
     "teamsChat"
   ],
   "config": {
-    "serviceURL": "https://teams.microsoft.com",
+    "serviceURL": "https://teams.live.com",
     "hasNotificationSound": true,
     "hasIndirectMessages": true
   }


### PR DESCRIPTION
Old serviceURL redirects to new serviceURL so should probably be updated.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

teams.microsoft.com (old serviceURL) redirects to teams.live.com (new serviceURL).
