### PR TITLE
ntfy: monkey patch to make notifications work

### DIFF
--- a/recipes/ntfy/package.json
+++ b/recipes/ntfy/package.json
@@ -1,7 +1,7 @@
 {
   "id": "ntfy",
   "name": "ntfy",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "aliases": [
     "Notify"

--- a/recipes/ntfy/webview-unsafe.js
+++ b/recipes/ntfy/webview-unsafe.js
@@ -1,0 +1,9 @@
+// monkey patch to make notifications work properly on electron
+window.ServiceWorkerRegistration.prototype.showNotification = function (
+  title,
+  options,
+) {
+  // passing all of options causes notifications to only appear sometimes
+  // but the only option that actually matters is body
+  new Notification(title, { body: options.body });
+};

--- a/recipes/ntfy/webview.js
+++ b/recipes/ntfy/webview.js
@@ -19,4 +19,6 @@ module.exports = Ferdium => {
   Ferdium.loop(getMessages);
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+
+  Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
 };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change
Ntfy uses service workers for notifications, which aren't supported in electron. This change reroutes notifications to use `new Notification()` instead.

fixes https://github.com/ferdium/ferdium-app/issues/1538