### PR TITLE
Add recipe for Microsoft Teams Personal (teams.live.com)

### DIFF
--- a/recipes/msteams-personal/index.js
+++ b/recipes/msteams-personal/index.js
@@ -1,0 +1,21 @@
+module.exports = Ferdium =>
+  class MicrosoftTeams extends Ferdium {
+    overrideUserAgent() {
+      return window.navigator.userAgent
+        .replaceAll(/(Ferdium|Electron)\/\S+ \([^)]+\)/g, '')
+        .trim();
+    }
+
+    // TODO: Commenting out since this can expose the user to a MITM attack. Before this can be turned on, we will need to put in some safeguards/warnings that the user can explicitly accept the security ramifications
+    // // https://docs.microsoft.com/en-us/microsoftteams/troubleshoot/teams-sign-in/sign-in-loop#resolution
+    // knownCertificateHosts() {
+    //   return [
+    //     'microsoft.com',
+    //     'microsoftonline.com',
+    //     'teams.skype.com',
+    //     'teams.microsoft.com',
+    //     'sfbassets.com',
+    //     'skypeforbusiness.com',
+    //   ];
+    // };
+  };

--- a/recipes/msteams-personal/package.json
+++ b/recipes/msteams-personal/package.json
@@ -1,0 +1,16 @@
+{
+  "id": "msteams-personal",
+  "name": "Microsoft Teams Personal",
+  "version": "3.3.2",
+  "license": "MIT",
+  "aliases": [
+    "teamsChat"
+  ],
+  "config": {
+    "serviceURL": "https://teams.live.com",
+    "hasNotificationSound": true,
+    "hasIndirectMessages": true
+  },
+  "defaultIcon": "https://cdn.jsdelivr.net/gh/ferdium/ferdium-recipes@main/recipes/msteams/icon.svg",
+  "message": "Use this to fix logouts when using the Personal team (teams.live.com). For 365-based teams (teams.microsoft.com) use the default Microsoft Teams service."
+}

--- a/recipes/msteams-personal/service.css
+++ b/recipes/msteams-personal/service.css
@@ -1,0 +1,63 @@
+notification-banner {
+	display: none !important;
+}
+.desktop-capturer-selection {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background: rgba(30,30,30,.75);
+  color: #fff;
+  z-index: 10000000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.desktop-capturer-selection__scroller {
+  width: 100%;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+.desktop-capturer-selection__list {
+  max-width: calc(100% - 100px);
+  margin: 50px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  overflow: hidden;
+  justify-content: center;
+}
+.desktop-capturer-selection__item {
+  display: flex;
+  margin: 4px;
+}
+.desktop-capturer-selection__btn {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 145px;
+  margin: 0;
+  border: 0;
+  border-radius: 3px;
+  padding: 4px;
+  background: #252626;
+  text-align: left;
+  transition: background-color .15s, box-shadow .15s;
+}
+.desktop-capturer-selection__btn:hover,
+.desktop-capturer-selection__btn:focus {
+  background: rgba(98,100,167,.8);
+}
+.desktop-capturer-selection__thumbnail {
+  width: 100%;
+  height: 81px;
+  object-fit: cover;
+}
+.desktop-capturer-selection__name {
+  margin: 6px 0 6px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/recipes/msteams-personal/webview-unsafe.js
+++ b/recipes/msteams-personal/webview-unsafe.js
@@ -1,0 +1,5 @@
+window.electronSafeIpc = {
+  send: () => null,
+  on: () => null,
+};
+window.desktop = undefined;

--- a/recipes/msteams-personal/webview.js
+++ b/recipes/msteams-personal/webview.js
@@ -1,0 +1,41 @@
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+
+const _path = _interopRequireDefault(require('path'));
+
+module.exports = Ferdium => {
+  const getMessages = () => {
+    let messages = 0;
+
+    const isTeamsV2 = window.location.href.includes('/v2/');
+
+    let badges = document.querySelectorAll(
+      '.activity-badge.dot-activity-badge .activity-badge',
+    );
+
+    if (isTeamsV2) {
+      badges = document.querySelectorAll('.fui-Badge');
+    }
+
+    if (badges) {
+      Array.prototype.forEach.call(badges, badge => {
+        messages += Ferdium.safeParseInt(badge.textContent);
+      });
+    }
+
+    const indirectMessages =
+      document.querySelectorAll('.app-bar-mention').length;
+
+    Ferdium.setBadge(messages, indirectMessages);
+  };
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdium.releaseServiceWorkers();
+  });
+
+  Ferdium.loop(getMessages);
+
+  Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
+};


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [ ] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) => _No, this is mostly a copy of an existing recipe_

#### Description of Change

Having both 365-teams (teams.microsoft.com) and a "Personal" team (teams.live.com) under the same account works for the 365-teams. When reloading the personal team though we have to confirm logging into the personal team again every time.

I added a copy of the msteams recipe and changed the base url to teams.live.com.

This way, the service now correctly logs in into the personal team without needing further interactions.
