### PR TITLE
fix(deepseek): change url to chat

### DIFF
--- a/recipes/deepseek/package.json
+++ b/recipes/deepseek/package.json
@@ -1,9 +1,9 @@
 {
   "id": "deepseek",
   "name": "DeepSeek",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://www.deepseek.com/"
+    "serviceURL": "https://chat.deepseek.com/"
   }
 }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change
I don't use this service myself, but according to https://github.com/ferdium/ferdium-app/issues/2029, the previous url was causing problems with chats not staying inside Ferdium but opening in the general browser.
<!-- Describe your changes in detail. -->
