### PR TITLE
Fix incorrect unread count in Outlook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferdium-recipes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "directories": {
     "doc": "docs"
   },

--- a/recipes/office365-owa/webview.js
+++ b/recipes/office365-owa/webview.js
@@ -10,7 +10,7 @@ module.exports = (Ferdium, settings) => {
     const foldersElement = document.querySelector(selector);
     if (foldersElement) {
       const allScreenReaders = foldersElement.querySelectorAll(
-        'span.screenReaderOnly',
+        '[aria-labelledby*="primaryMailboxRoot"] span.screenReaderOnly',
       );
       for (const child of allScreenReaders) {
         if (child.previousSibling) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

The unread messages count in the Outlook recipe counts all unread messages and this leads to double count of repeated folders. I.e. the Inbox folder in the favourites section and the Inbox folder in an account section will be counted twice (see screenshot).

<img width="732" height="987" alt="tmp" src="https://github.com/user-attachments/assets/85ceba47-2bef-4923-8b41-5b9089a48a68" />

