### PR TITLE
Todoist: fix badge count

### DIFF
--- a/recipes/todoist/package.json
+++ b/recipes/todoist/package.json
@@ -1,7 +1,7 @@
 {
   "id": "todoist",
   "name": "Todoist",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "repository": "https://github.com/meetfranz/recipe-todoist",
   "config": {

--- a/recipes/todoist/webview.js
+++ b/recipes/todoist/webview.js
@@ -23,7 +23,7 @@ module.exports = Ferdium => {
       inboxCount = Ferdium.safeParseInt(inboxElement.textContent);
     }
 
-    Ferdium.setBadge(inboxCount, todayCount);
+    Ferdium.setBadge(todayCount, inboxCount);
   }
 
   Ferdium.loop(getTasks);


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Previously the Todoist recipe would show the "inbox" count as mentions and "today" count as total messages. This PR flips the two around so that the "today" count shows as mentions and "inbox" count as total. 

This makes more sense because tasks due today is a subset of the total tasks in the inbox.
