### PR TITLE
Fix unread message counts for Office365-OWA recipe

### DIFF
--- a/recipes/office365-owa/package.json
+++ b/recipes/office365-owa/package.json
@@ -1,7 +1,7 @@
 {
   "id": "office365-owa",
   "name": "Office 365 Outlook",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "license": "MIT",
   "aliases": [
     "live.com",

--- a/recipes/office365-owa/webview.js
+++ b/recipes/office365-owa/webview.js
@@ -70,8 +70,8 @@ module.exports = (Ferdium, settings) => {
       // new app
       directUnreadCount =
         settings.onlyShowFavoritesInUnreadCount === true
-          ? collectCounts('div[role=tree]:nth-child(2)')
-          : collectCounts('div[role=tree]:nth-child(1)');
+          ? collectCounts('div[role=tree]>:nth-child(2)')
+          : collectCounts('div[role=tree]>:nth-child(3)');
 
       indirectUnreadCount = collectCounts('div[role=tree]:nth-child(4)'); // groups
     }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

<!-- Describe your changes in detail. -->
Unread message count was showing a total of all messages, including favorites and all folders, so unread messages were counted twice. Also toggling option to only show favorite folders in unread message count resulted in unread message count always being 0.
I changed the selector used to select the root element of messages to take the correct element depending on the "only show favorite in unread" option.
