### PR TITLE
Updated Microsoft Teams to the new URL

### DIFF
--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "msteams",
   "name": "Microsoft Teams",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "license": "MIT",
   "aliases": [
     "teamsChat"

--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -7,7 +7,7 @@
     "teamsChat"
   ],
   "config": {
-    "serviceURL": "https://teams.microsoft.com",
+    "serviceURL": "https://teams.cloud.microsoft",
     "hasNotificationSound": true,
     "hasIndirectMessages": true
   }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [X] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

<!-- Describe your changes in detail. -->

This PR fixes issue: https://github.com/ferdium/ferdium-app/issues/2320

Microsoft is switching Teams to the new URL: https://teams.cloud.microsoft

People are slowly starting to get notifications that the is the "new" and "more secure" URL. So we need to switch over.

The new URL is already live and I am already using it in the browser.