### PR TITLE
Fix attachment download click handling in Office 365 Outlook recipe

### DIFF
--- a/recipes/office365-owa/package.json
+++ b/recipes/office365-owa/package.json
@@ -1,7 +1,7 @@
 {
   "id": "office365-owa",
   "name": "Office 365 Outlook",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "license": "MIT",
   "aliases": [
     "live.com",

--- a/recipes/office365-owa/webview.js
+++ b/recipes/office365-owa/webview.js
@@ -28,30 +28,46 @@ module.exports = (Ferdium, settings) => {
   document.addEventListener(
     'click',
     event => {
-      const link = event.target.closest('a');
-      const button = event.target.closest('button');
+      const targetElement = event.target;
+      if (!(targetElement instanceof Element)) {
+        return;
+      }
+      const link = targetElement.closest('a[href]');
 
-      if (link || button) {
-        const url = link
-          ? link.getAttribute('href')
-          : button.getAttribute('title');
+      if (!link || Ferdium.isImage(link)) {
+        return;
+      }
 
-        // check if the URL is relative or absolute
-        if (url.startsWith('/')) {
-          return;
-        }
+      const url = link.getAttribute('href');
+      if (!url || url === '#') {
+        return;
+      }
 
-        // check if we have a valid URL that is not a script nor an image:
-        if (url && url !== '#' && !Ferdium.isImage(link)) {
-          event.preventDefault();
-          event.stopPropagation();
+      // Keep in-app navigation untouched.
+      if (url.startsWith('/')) {
+        return;
+      }
 
-          if (settings.trapLinkClicks === true) {
-            window.location.href = url;
-          } else {
-            Ferdium.openNewWindow(url);
-          }
-        }
+      let parsedUrl;
+      try {
+        parsedUrl = new URL(url, window.location.href);
+      } catch {
+        return;
+      }
+
+      if (
+        !['http:', 'https:', 'ftp:', 'mailto:'].includes(parsedUrl.protocol)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (settings.trapLinkClicks === true) {
+        window.location.href = parsedUrl.toString();
+      } else {
+        Ferdium.openNewWindow(parsedUrl.toString());
       }
     },
     true,


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number)

#### Description of Change

This PR fixes the Office 365 Outlook recipe click handler so attachment downloads work again and runtime errors are avoided.

Changes:
- In `recipes/office365-owa/webview.js`, intercept only external anchor links (`a[href]`) instead of generic `a/button` clicks.
- Add guards for non-Element targets and missing/invalid URLs.
- Keep relative URLs (`/`) untouched to avoid interfering with Outlook internal navigation/actions.
- Parse URLs safely and allow only external protocols (`http`, `https`, `ftp`, `mailto`) before trapping.
- Prevent null access errors seen in runtime:
  - `Cannot read properties of null (reading 'startsWith')`
  - `Cannot read properties of null (reading 'dataset')`
- Bump `recipes/office365-owa/package.json` from `1.7.4` to `1.7.5`.

Validation:
- Tested locally in Ferdium (`pnpm debug`) with Outlook Web: attachment download flow works.
- Ran `pnpm -C recipes validate` successfully.

#### Release Notes

Fix Office 365 Outlook recipe link interception to restore attachment downloads and prevent runtime click-handler errors.