### PR TITLE
Update Messenger service URL to facebook.com/messages

### DIFF
--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,10 +1,10 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://messenger.com",
+    "serviceURL": "https://facebook.com/messages",
     "hasNotificationSound": true
   }
 }


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [X] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [X] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

This PR updates the Messenger recipe to use the Facebook Messages URL and increments the version number.

- Updated `serviceURL` from https://messenger.com to https://facebook.com/messages in package.json.
- Bumped version from 1.8.5 to 1.8.6 to ensure Ferdium users receive the update.

I ran the required validation checks according to https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md.

#### Related Issues
   - ferdium/ferdium-app#2341

#### Reference

- [Messenger.com is no longer available for messaging](https://www.facebook.com/help/messenger-app/804132271957789) (Facebook KM)- Official documentation confirming facebook.com/messages as the new primary web entry point.