### PR TITLE
fix(paperless-ngx): add icon file to fix inaccessible remote image

### DIFF
--- a/recipes/paperless-ngx/icon.svg
+++ b/recipes/paperless-ngx/icon.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="900"
+   height="900"
+   id="svg3923"
+   sodipodi:docname="square.svg"
+   inkscape:export-filename="/tmp/test.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <metadata
+     id="metadata3929">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3927" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2096"
+     id="namedview3925"
+     showgrid="false"
+     inkscape:zoom="1.1360927"
+     inkscape:cx="635.07139"
+     inkscape:cy="606.383"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3921" />
+  <g
+     transform="matrix(10.638298,0,0,10.638298,106.38298,-206.38301)"
+     id="g3921">
+    <defs
+       id="SvgjsDefs1018" />
+    <g
+       id="SvgjsG1019"
+       featureKey="root"
+       style="fill:#ffffff" />
+    <g
+       id="SvgjsG1020"
+       featureKey="symbol1"
+       transform="matrix(0.10341565,0,0,0.10341565,-11.43874,18.048418)"
+       inkscape:export-filename="/tmp/test.png"
+       inkscape:export-xdpi="116.02285"
+       inkscape:export-ydpi="116.02285"
+       style="fill:#17541f">
+      <defs
+         id="defs3911" />
+      <g
+         id="g3915">
+        <path
+           d="M 231,798 C 227,779 219,741 218,741 49,640 69,465 125,365 c 12,126 235,213 105,367 -1,2 6,26 12,48 26,-44 65,-97 63,-102 C 145,288 645,258 749,16 c 47,234 -24,596 -426,688 -2,1 -73,126 -76,127 0,-2 -30,-1 -26,-11 2,-6 6,-14 10,-22 z M 330,625 C 267,476 452,312 544,271 356,439 324,564 330,625 Z m -104,79 c 51,-59 -9,-160 -45,-193 61,105 57,166 45,193 z"
+           style="fill:#17541f"
+           id="path3913"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/recipes/paperless-ngx/icon.svg
+++ b/recipes/paperless-ngx/icon.svg
@@ -1,82 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="900"
-   height="900"
-   id="svg3923"
-   sodipodi:docname="square.svg"
-   inkscape:export-filename="/tmp/test.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
-   inkscape:version="0.92.2 2405546, 2018-03-11">
-  <metadata
-     id="metadata3929">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs3927" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="2096"
-     id="namedview3925"
-     showgrid="false"
-     inkscape:zoom="1.1360927"
-     inkscape:cx="635.07139"
-     inkscape:cy="606.383"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g3921" />
-  <g
-     transform="matrix(10.638298,0,0,10.638298,106.38298,-206.38301)"
-     id="g3921">
-    <defs
-       id="SvgjsDefs1018" />
-    <g
-       id="SvgjsG1019"
-       featureKey="root"
-       style="fill:#ffffff" />
-    <g
-       id="SvgjsG1020"
-       featureKey="symbol1"
-       transform="matrix(0.10341565,0,0,0.10341565,-11.43874,18.048418)"
-       inkscape:export-filename="/tmp/test.png"
-       inkscape:export-xdpi="116.02285"
-       inkscape:export-ydpi="116.02285"
-       style="fill:#17541f">
-      <defs
-         id="defs3911" />
-      <g
-         id="g3915">
-        <path
-           d="M 231,798 C 227,779 219,741 218,741 49,640 69,465 125,365 c 12,126 235,213 105,367 -1,2 6,26 12,48 26,-44 65,-97 63,-102 C 145,288 645,258 749,16 c 47,234 -24,596 -426,688 -2,1 -73,126 -76,127 0,-2 -30,-1 -26,-11 2,-6 6,-14 10,-22 z M 330,625 C 267,476 452,312 544,271 356,439 324,564 330,625 Z m -104,79 c 51,-59 -9,-160 -45,-193 61,105 57,166 45,193 z"
-           style="fill:#17541f"
-           id="path3913"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-  </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1000 1000">
+  <defs>
+    <style>
+      .st0 {
+        fill: #005616;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M341,949.1c-6.9-20.3-20.7-61.2-21.9-61-199.6-88.9-182.5-229.8-134.3-347.5,30,137.2,268.8,148.9,146.2,336-.9,2.2,10,27.8,19.5,51.3,22.7-51.9,58.6-115.5,55.8-120.8C178,398.7,724.9,299,807.1,18.5c83,251.5,53.1,659.8-377.4,814.9-2,1.4-63.5,148.6-66.9,150.2-.2-2.1-33.2,2.9-30.1-8.7,1.6-7,4.8-16.2,8.2-25.6h0v-.2h.1ZM323.1,846.2c48.3-71.9-12.7-120.8-56.9-152.2,81.2,107.4,66.4,120.8,56.9,152.2h0Z"/>
 </svg>

--- a/recipes/paperless-ngx/package.json
+++ b/recipes/paperless-ngx/package.json
@@ -1,10 +1,9 @@
 {
   "id": "paperless-ngx",
-  "name": "Paperless NGX",
-  "version": "1.0.0",
+  "name": "Paperless-ngx",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true
-  },
-  "defaultIcon": "https://docs.paperless-ngx.com/assets/favicon.png"
+  }
 }


### PR DESCRIPTION
fix(paperless-ngx): use official app title

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Adds local icon from official repo[^1] and removes inaccessible remote image url from package

Change the app title to match the official[^2] spelling "Paperless-ngx".

```shell
pnpm lint:fix && pnpm reformat-files && pnpm package
...
recipes/paperless-ngx/index.js 1ms (unchanged)
recipes/paperless-ngx/package.json 1ms (unchanged)
recipes/paperless-ngx/webview.js 3ms (unchanged)
...
✅ Successfully packaged and added 410 recipes (0 unsuccessful recipes) in 79.983 seconds
```

[^1]: https://github.com/paperless-ngx/paperless-ngx/blob/dev/resources/logo/web/svg/square.svg
[^2]: https://docs.paperless-ngx.com/