### PR TITLE
fix(google-calendar): remove workspace redirect that causes infinite loop

### DIFF
--- a/recipes/google-calendar/webview.js
+++ b/recipes/google-calendar/webview.js
@@ -5,15 +5,6 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
-  // if the user is on googlecalendar landing page, go to the login page.
-  if (
-    location.hostname === 'workspace.google.com' &&
-    location.href.includes('products/calendar/')
-  ) {
-    location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://calendar.google.com/u/0/';
-  }
-
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
   Ferdium.injectCSS(
     'https://cdn.statically.io/gh/ferdium/ferdium-recipes/main/recipes/google-calendar/calendar.css',


### PR DESCRIPTION
## Summary

- Remove the `workspace.google.com` redirect from the Google Calendar recipe

Google changed the behavior of `AccountChooser` for unauthenticated embedded browsers (Electron): it now redirects back to `calendar.google.com`, which in turn redirects to `workspace.google.com/products/calendar/`, triggering the recipe's redirect again. This creates an infinite redirect loop (~1 redirect/second).

**Redirect chain:**
1. `calendar.google.com/u/0/` → Google redirects to `workspace.google.com/products/calendar/`
2. Recipe detects `workspace.google.com` → redirects to `accounts.google.com/AccountChooser`
3. `AccountChooser` → redirects back to `calendar.google.com/u/0/`
4. **Loop repeats**

Removing the redirect stops the loop. The service lands on the workspace marketing page instead of looping, and users who are already authenticated (via shared session or existing cookies) will load Calendar normally.