### PR TITLE
fix(google-gemini): remove workspace.google.com redirect

### DIFF
--- a/recipes/google-gemini/webview.js
+++ b/recipes/google-gemini/webview.js
@@ -5,14 +5,6 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
-  if (
-    location.hostname === 'workspace.google.com' &&
-    location.href.includes('products/gemini/')
-  ) {
-    location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://gemini.google.com/u/0/';
-  }
-
   Ferdium.handleDarkMode(isEnabled => {
     localStorage.setItem('theme', isEnabled ? 'dark' : 'light');
   });


### PR DESCRIPTION
## Summary

- Remove the `workspace.google.com` redirect block from `webview.js` that caused a redirect loop preventing users from using Gemini

The recipe's `webview.js` contained a redirect block inherited from other Google recipes that detects `workspace.google.com` and redirects to `AccountChooser`. Since Google now redirects unauthenticated users to `workspace.google.com`, this creates an infinite redirect loop (`gemini.google.com` -> `workspace.google.com` -> `AccountChooser` -> `gemini.google.com` -> ...).

Related issues:
- https://github.com/ferdium/ferdium-app/issues/639
- https://github.com/ferdium/ferdium-app/issues/1064
- https://github.com/ferdium/ferdium-app/issues/2273
- Similar fix for Google Calendar: https://github.com/ferdium/ferdium-recipes/pull/687