### PR TITLE
fix(gaming-on-linux) add notification counter

### DIFF
--- a/recipes/gaming-on-linux/package.json
+++ b/recipes/gaming-on-linux/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gaming-on-linux",
   "name": "GamingOnLinux",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.gamingonlinux.com"

--- a/recipes/gaming-on-linux/webview.js
+++ b/recipes/gaming-on-linux/webview.js
@@ -5,12 +5,27 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
-  // TODO: If your SNAME service has unread messages, uncomment these lines to implement the logic for updating the badges
-  // const getMessages = () => {
-  //   // TODO: Insert your notification-finding code here
-  //   Ferdium.setBadge(0, 0);
-  // };
-  // Ferdium.loop(getMessages);
+  function getNotificationCount() {
+    let notifications = document.querySelector(
+      '#normal_notifications > a:nth-child(1) > span',
+    ).innerHTML;
+    return Ferdium.safeParseInt(notifications);
+  }
 
+  function getMessageCount() {
+    let messages = document.querySelector('#pm_counter').innerHTML;
+    return Ferdium.safeParseInt(messages);
+  }
+
+  const updateMessageCount = () => {
+    let count = getNotificationCount() + getMessageCount();
+    Ferdium.setBadge(count);
+  };
+
+  const loopRoutine = () => {
+    updateMessageCount();
+  };
+
+  Ferdium.loop(loopRoutine);
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
 };


### PR DESCRIPTION
- added the notification counter to GamingOnLinux

Previously the GamingOnLinux recipe was basically just a prebuilt adress and icon. Now I added the badge to display the (combined) message and notification counters from the page myself.