### PR TITLE
MS Teams: fix unread messages count

### DIFF
--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "msteams",
   "name": "Microsoft Teams",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "license": "MIT",
   "aliases": [
     "teamsChat"

--- a/recipes/msteams/webview.js
+++ b/recipes/msteams/webview.js
@@ -17,7 +17,7 @@ module.exports = Ferdium => {
     );
 
     if (isTeamsV2) {
-      badges = document.querySelectorAll('.fui-Badge');
+      badges = document.querySelectorAll('div[data-testid="hamburger-button-badge"]');
     }
 
     if (badges) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Teams introduced new badge for hamburger button with the total of unread messages. Since it utilizes fui-Badge class as well it's not possible to distinct this badge from others and leading to wrong unread messages count shown by the Ferdium.