### PR TITLE
fix(hangoutschat): update favicon selector for Google Chat 2026 redesign

### DIFF
--- a/recipes/hangoutschat/webview.js
+++ b/recipes/hangoutschat/webview.js
@@ -24,7 +24,7 @@ module.exports = Ferdium => {
 
     // get unread messages count
     directCount = document.querySelectorAll(
-      'link[href^="https://ssl.gstatic.com/ui/v1/icons/mail/images/favicon_chat_new_notif_"][href$=".ico"]',
+      'link[rel*="icon"][href*="_favicon_dot_"]',
     ).length;
 
     // get unread indirect messages


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [ ] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [ ] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

## What

Updates the unread-message favicon selector in the `hangoutschat` recipe to match Google Chat's post-May-2026 favicon URL.

## Why

After Google's 2026 Workspace icon rollout, Google Chat now serves its favicon from a new location with a new filename pattern. The old selector no longer matches anything, so the Ferdium badge never appears for unread direct messages.
