### PR TITLE
fix(chatwoot): allow selfhosted installations with custom url

### DIFF
--- a/recipes/chatwoot/package.json
+++ b/recipes/chatwoot/package.json
@@ -1,10 +1,12 @@
 {
   "id": "chatwoot",
   "name": "Chatwoot",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "license": "MIT",
-  "repository": "https://github.com/maximeMD/ferdi-chatwoot",
   "config": {
-    "serviceURL": "https://app.chatwoot.com/app/login"
+    "serviceURL": "https://app.chatwoot.com/",
+    "message": "Chatwoot's default URL is https://app.chatwoot.com/",
+    "hasHostedOption": true,
+    "hasCustomUrl": true
   }
 }


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

- Enable HostedOption to allow custom url

Only had the SaaS service url defined but must allow self-hosted[^2] installs as well.

From the official description

> Chatwoot is the modern, open-source, and **self-hosted customer support platform** designed to help businesses deliver exceptional customer support experience.[^1]

Resolves https://github.com/ferdium/ferdium-app/issues/2421

[^1]: https://github.com/chatwoot/chatwoot
[^2]: https://www.chatwoot.com/deploy