### PR TITLE
fix google auth redirects

### DIFF
--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -11,7 +11,7 @@ module.exports = Ferdium => {
     location.href.includes('gmail/about/')
   ) {
     location.href =
-      'https://accounts.google.com/AccountChooser?service=mail&continue=https://mail.google.com/mail/';
+      'https://accounts.google.com/ServiceLogin?service=mail&continue=https://mail.google.com/mail/';
   }
 
   const getMessages = () => {

--- a/recipes/google-calendar/package.json
+++ b/recipes/google-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-calendar",
   "name": "Google Calendar",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "license": "MIT",
   "aliases": [
     "google-calendar",

--- a/recipes/google-calendar/webview.js
+++ b/recipes/google-calendar/webview.js
@@ -11,7 +11,7 @@ module.exports = Ferdium => {
     location.href.includes('products/calendar/')
   ) {
     location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://calendar.google.com/u/0/';
+      'https://accounts.google.com/ServiceLogin?continue=https://calendar.google.com/u/0/';
   }
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));

--- a/recipes/google-classroom/package.json
+++ b/recipes/google-classroom/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-classroom",
   "name": "Google Classroom",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "repository": "https://github.com/TanZng/ferdi-googleclassroom",
   "config": {

--- a/recipes/google-classroom/webview.js
+++ b/recipes/google-classroom/webview.js
@@ -11,7 +11,7 @@ module.exports = Ferdium => {
     location.href.includes('workspace-for-education/classroom/')
   ) {
     location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://classroom.google.com/u/0/';
+      'https://accounts.google.com/ServiceLogin?continue=https://classroom.google.com/u/0/';
   }
 
   const getMessages = () => {

--- a/recipes/google-gemini/package.json
+++ b/recipes/google-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-gemini",
   "name": "Google Gemini",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://gemini.google.com"

--- a/recipes/google-gemini/webview.js
+++ b/recipes/google-gemini/webview.js
@@ -10,7 +10,7 @@ module.exports = Ferdium => {
     location.href.includes('products/gemini/')
   ) {
     location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://gemini.google.com/u/0/';
+      'https://accounts.google.com/ServiceLogin?continue=https://gemini.google.com/u/0/';
   }
 
   Ferdium.handleDarkMode(isEnabled => {

--- a/recipes/hangoutschat/package.json
+++ b/recipes/hangoutschat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangoutschat",
   "name": "Hangouts Chat",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "aliases": [
     "google-chat",

--- a/recipes/hangoutschat/webview.js
+++ b/recipes/hangoutschat/webview.js
@@ -11,7 +11,7 @@ module.exports = Ferdium => {
     location.href.includes('products/chat/')
   ) {
     location.href =
-      'https://accounts.google.com/AccountChooser?continue=https://chat.google.com/?referrer=2';
+      'https://accounts.google.com/ServiceLogin?continue=https://chat.google.com/?referrer=2';
   }
 
   // class corresponding to the bold text that is visible for room messages


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

## Summary

- Replace Google `AccountChooser` redirects with `ServiceLogin` for affected Google recipes.
- Keep existing `continue` targets so Gmail, Calendar, Classroom, Gemini, and Google Chat authenticate inside Ferdium instead of falling back to external/browser flows.
- Bump affected recipe versions.

## Linked Issues

Fixes [#2439](https://github.com/ferdium/ferdium-app/issues/2439)
Related to [#2344](https://github.com/ferdium/ferdium-app/issues/2344)
Related to [#2082](https://github.com/ferdium/ferdium-app/issues/2082)
(anothers?)

## Testing

- Verified no `accounts.google.com/AccountChooser` references remain.
