### PR TITLE
feat(claude-ai): enable custom URL support

### DIFF
--- a/recipes/claude-ai/package.json
+++ b/recipes/claude-ai/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://claude.ai"
+    "serviceURL": "https://claude.ai",
+    "hasCustomUrl": true
   }
 }

--- a/recipes/claude-ai/package.json
+++ b/recipes/claude-ai/package.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-ai",
   "name": "claude.ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://claude.ai",


### PR DESCRIPTION
## Summary
- Enables `hasCustomUrl` for the Claude AI recipe so users can configure a custom landing URL
- Claude now offers multiple experiences at different paths (e.g. `claude.ai/code`, `claude.ai/design`) and users may want to land directly on one of them instead of the default `claude.ai` chat

## Test plan
- [x] Add Claude AI service with default URL — should still work as before (`https://claude.ai`)
- [x] Add Claude AI service with custom URL set to `https://claude.ai/code` — should land on Claude Code
- [x] Add Claude AI service with custom URL set to `https://claude.ai/design` — should land on Claude Design