### PR TITLE
Add darkmode for Gmail incl. Gemini side panel

### DIFF
--- a/recipes/gmail/darkmode.css
+++ b/recipes/gmail/darkmode.css
@@ -1,0 +1,660 @@
+* {
+  scrollbar-color: #383d3f #131617;
+}
+
+
+.jfk-bubble.gtx-bubble, .captcheck_answer_label > input + img, span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"], span[data-href^="https://www.hcaptcha.com/"] > #icon, img.Wirisformula, .asor_t0, .asor_i1 > img, .asor_i4, .d-Na-Jo.d-Na-N-ax3, .RK-QJ-Jk, .RK-Mo.RK-Qq-LF, #ita-st-id-cs, .d-Na-N-M7-JX.d-Na-J3, .gb_df, img[src$="google_gsuite"], img[src$="profile_mask2.png"], .rY>.sa, .buh, .asor, .mixmax-flyout__wrapper, div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div, form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id]), img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"], div[style$="gm_add_black_24dp.png)"] {
+  filter: invert(1) !important;
+}
+
+.aiw .cd .vh {
+	display: none !important;
+}
+
+body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
+  color: #fff !important;
+}
+.a98  > table {
+  background-color: var(--gm3-sys-color-on-background) !important;
+}
+.a98 > a {
+  color: blue !important;
+}
+.a98 > *, .a98 *, .a98{
+  background-color: var(--gm3-sys-color-on-background) !important;   
+  color: #fff !important;
+}
+.hP, .gD, .go, .gK  {
+  color:  #fff !important;;
+}
+.a3s.aiL > div > div > table > tbody, .a3s.aiL > div > table {
+  background-color: var(--gm3-sys-color-on-background) !important;
+  color: #fff;
+}
+.a3s.aiL > div {
+  background-color: var(--gm3-sys-color-on-background) !important;
+  color: #fff;
+} 
+.a3s.aiL a, .a3s.aiL a:link, .a3s.aiL a:visited, .a3s.aiL a:hover, .a3s.aiL a:active,
+.a3s a, .a3s a:link, .a3s a:visited, .a3s a:hover, .a3s a:active {
+  color: #63a3ff !important;
+  text-decoration: underline !important;
+}
+.rPlcIc {
+  color: white;
+  border: 1px solid;
+  background-color: var(--gm3-sys-color-on-background);
+}
+.amn {
+  background-color: var(--gm3-sys-color-on-background);   
+}
+.amr .amn>.ams {
+  color: white;
+}
+.jWOS7-JX-I {
+  color: var(--gm3-sys-color-on-surface-variant);
+  border: white 1px solid;
+}
+.hx {
+  color: #ffff;
+}
+.ajA {
+  background-color: var(--gm3-sys-color-on-background);
+  color: #fff !important;
+}
+.m_1101107240044101454nl-m-block-table {
+  background-color: var(--gm3-sys-color-on-background);
+}
+.m_-9085597476244977982es-m-p20t {
+  background-color: var(--gm3-sys-color-on-background);
+}
+
+.m_-3410381025534480928es-content {
+  background-color: var(--gm3-sys-color-on-background);
+}
+
+.a3s, .a3s > div, .a3s > * .aiL > * {
+  background-color: var(--gm3-sys-color-on-background);
+} 
+
+#loading  {
+  background-color: rgb(14, 16, 17) !important;
+}
+.la-k .la-m {
+  background-color: rgb(14, 16, 17) !important;
+}
+.la-i > .la-m, .la-i {
+  background-image: initial;
+  background-color: rgb(14, 16, 17) !important;
+}
+.roster_comm_link, .la-i > div, .aDG {
+  background-color: rgb(14, 16, 17) !important;
+}
+.m_6739384714865278520es-m-txt-c > h1{
+  color: #fff !important; 
+}
+.m_-5899876277505173878tag {
+  background-color:rgb(14, 16, 17)!important;
+  color: #fff !important;
+}
+
+.msg-5476942933920871755, .m_-5476942933920871755bg-cover {
+  background-color:rgb(14, 16, 17)!important;
+}
+.msg8210101856495818180 .m_8210101856495818180bg-cover {
+  background-color:rgb(14, 16, 17)!important;
+
+}
+
+.rPlcIc {
+  border: none;
+}
+
+.z0 > .L3 {
+  box-shadow: rgba(35, 39, 41, 0.3) 0px 1px 2px 0px, rgba(35, 39, 41, 0.15) 0px 1px 3px 1px;
+  transition: box-shadow .08s linear, min-width .15s cubic-bezier(0.4,0,0.2,1);
+  background-color: rgb(21 21 21) !important;
+  background-image: none;
+  color: rgb(155, 148, 137);
+}
+
+.IU {
+  background-color: rgb(18, 20, 22) !important;
+  box-shadow: none !important;
+}
+
+.d-Na-JG-M {
+  background-color: #1c1c1c !important;
+}
+
+#kbd {
+  background-color:rgb(11, 13, 14) !important;
+}
+
+.uW2Fw-bHp, .uW2Fw-bHp-K0, .uW2Fw-bHk {
+  color: #fff !important;
+}
+
+
+.mUIrbf-I {
+  background-color: gray !important;
+}
+.av {
+  background-color: rgb(49, 49, 49) !important;
+}
+
+.J-M {
+  background-color: rgb(11, 13, 14)  !important;
+  border: gray 1px solid;
+  border-radius: 10px;
+}
+
+.bAq, .aT {
+  color: #000000;
+}
+
+.t9 {
+  background:rgb(11, 13, 14)  !important;
+}
+
+.aRp, .aRp + tr {
+  background:rgb(11, 13, 14)  !important;
+}
+
+.gstl_50.gssb_c {
+  background:rgb(11, 13, 14)  !important;
+}
+
+.HY, .HW , .HW.H0.H2 {
+  background-color: rgb(39, 44, 46);
+}
+
+.gssb_e {
+  background-color: rgb(11, 13, 14) !important;
+}
+.aqe {
+  background-color: rgb(11, 13, 14);
+}
+
+.gb_Kc.gb_hd, .gb_hd.gb_id, .gb-qe{
+  background-color: rgb(11, 13, 14) !important;
+  color: #fff !important;
+}
+
+.gb_hd.gb_id .gb_qe {
+  color: #fff !important;
+}
+
+.gssb_i {
+  background-color: rgb(21, 23, 25) !important;   
+}
+
+.J-N {
+  background-color: rgb(11, 13, 14) !important;
+}
+
+.J-N-JT, .J-N-JW {
+  background-color: rgb(21, 23, 25) !important;
+  border-color: rgb(40, 44, 46) !important;
+}
+
+.J-N > div > div, .J-N > div > div > div > .J-Kh > div > div, .b7.J-M > div > div > div > div, .b7.J-M > div > div > div, .b7.J-M > div > div > div > div > div {
+  background-color: transparent !important;
+}
+
+.bAp.b8.UC .vh {
+  box-shadow: rgba(35, 39, 41, 0.3) 0px 1px 3px 0px, rgba(35, 39, 41, 0.15) 0px 4px 8px 3px;
+  background-color: rgb(11, 13, 14);
+  border-width: initial;
+  border-style: none;
+  border-color: initial;
+  color: rgb(155, 148, 137);
+}
+
+.uW2Fw-bHk, .ko35Z {
+  background-color: rgb(11, 13, 14) !important;
+  color: #4497e7;
+}
+
+.TVkVld {
+  color: #fff;
+}
+
+.BpjaJf:last-of-type {
+  background-color: rgb(11, 13, 14) !important;
+} 
+
+.RK-Jk {
+  border-color: rgba(126, 116, 101, 0.1)  !important;
+  color: rgb(174, 168, 161) !important;
+  background-color: rgb(17, 19, 20)  !important;
+  background-image: linear-gradient(rgb(17, 19, 20), rgb(19, 22, 23))  !important;
+}
+.RK-Jk.RK-Qq-MY {
+  border-color: rgb(51, 56, 59)  !important;
+  color: rgb(196, 192, 186)  !important;
+  background-color: rgb(15, 17, 18 ) !important;
+  background-image: linear-gradient(rgb(15, 17, 18), rgb(19, 22, 23))  !important;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 1px  !important;
+}
+
+.d-Na-N:hover {
+  background-color: rgb(17, 19, 20)  !important;
+  color: rgb(196, 192, 186)  !important;
+  transition: color 0.3s ease
+}
+
+.d-Na-N-JW {
+  background-color: rgb(17, 19, 20)  !important;
+  color: rgb(196, 192, 186)  !important;
+}
+
+.m_2748637039718987311bg-cover > div {
+  max-width: 100%;
+}
+
+[data-darkreader-inline-bgimage] {
+  background-image: none !important;
+}
+
+
+.d-Qs-Md {
+  background-color: rgb(11, 13, 14)   !important;
+  box-shadow: rgb(63, 69, 72) 1px 4px 15px   !important;
+}
+.d-Qs-M8-ayz, .d-Qs-KO-ayz {
+  border-color: rgb(44, 48, 51)   !important;
+}
+.d-Qs-Jh-JF {
+  background-color: rgb(11, 13, 14)   !important;
+}
+
+.ua.bk5 {
+  background-color: rgb(21, 23, 25) !important;   
+}
+
+.ZF-z6, .ZF-zT, .ZF-Av .lJ, .ZF-Av .lN {
+  background-color: rgb(11, 13, 14);
+}
+
+.boo .nr {
+  background-color: transparent !important;
+}
+
+.ZH {
+  color: rgba(255, 255, 255, 0.705);
+}
+
+.nr, .bs3 {
+  color: rgba(255, 255, 255, 0.705) !important;;
+}
+.TO.nZ, .TO.NQ {
+  background-color: rgba(108, 108, 108, 0.2) !important;
+}
+
+.msg-7895207889899298162 .m_-7895207889899298162bg-cover, .msg5898900423439880409 .m_5898900423439880409bg-cover, .msg3174298617804948066 .m_3174298617804948066bg-cover, .m_-5635427342892673441bg-cover, .msg-5847429093741280064 .m_-5847429093741280064bg-cover  {
+  background: rgb(15, 17, 18) !important;
+}
+.m_-7895207889899298162bg-cover {
+  background: rgb(15, 17, 18) !important;
+}
+.uW2Fw-JD:not(.uW2Fw-JD-ql-aPH) :is(.uW2Fw-bHl,.uW2Fw-bHp,.uW2Fw-bHg) {
+  background: rgb(11, 13, 14) !important;
+}
+
+.mUIrbf-I::before {
+  background-color: rgb(11, 13, 14) !important;
+  border: 2px solid gray;
+}
+
+.tB5Jxf-M-X.tB5Jxf-wdeprb-MD85tf-DKzjMe.tB5Jxf-M-X-ql-aPs.tB5Jxf-M-X-ql-avs-QBLLGd.S8daBe-YPmvEd.S8daBe-uG8BId.O68mGe-M.tB5Jxf-M-X-ql-aLT-Kq-uFfGwd.tB5Jxf-M-X-ql-Kq {
+  background: black;
+}
+
+.AD > *, div#\:rm, div#\:p6, .aYF span {
+  color: #000000 !important;
+}
+
+.ZZ {
+  background-color: rgb(27, 27, 27) !important;
+}
+.SK.ZF-zT {
+  border: #101010 1px solid !important;
+
+}
+
+.alO {
+  background-color: rgba(11, 13, 14, 0.95) !important;
+
+}
+.v .f1 {
+  color: rgb(157, 149, 138) !important;
+  background-image: initial;
+  background-color: rgb(11, 13, 14) !important;
+}
+.v .fY {
+  background-image: initial;
+  background-color: rgb(11, 13, 14) !important;
+}
+
+.bkK > .nH {
+  background-color: rgba(25, 29, 30, 0.8) !important;
+}
+
+.r4 {
+    background-color: rgba(11, 13, 14, 0.95) !important;
+}
+.r4 {
+    padding: 0 24px 24px;
+}
+
+
+.Ht {
+  background-color: rgb(19, 19, 19);
+}
+
+.AD > *, div#\:rm, div#\:p6, .aYF span {
+  color: rgb(217, 215, 212) !important;
+}
+
+.Hl, .Hk, .Hq, .Ha {
+  filter: invert(1);
+}
+
+.aaZ {
+  background-color: rgb(11, 13, 14) !important;
+}
+
+.agP, .afx {
+  background: #1a1d1f !important;
+  color: rgb(196, 192, 186) !important;
+}
+
+.aoI {
+  background-color: rgb(11, 13, 14) !important;
+}
+.nr, .Ar {
+  border-color: rgb(92, 85, 73) rgb(49, 55, 57) rgb(49, 55, 57) !important;
+  background-color: rgb(11, 13, 14) !important;
+  color: rgb(196, 192, 186) !important;
+}
+.aoT, div#\:rm {
+  background-color: rgb(11, 13, 14) !important;
+  color: rgb(196, 192, 186) !important;
+}
+
+div#\:st {
+  color: rgb(196, 192, 186) !important;
+  filter: invert(1) !important;
+}
+
+tr.J-Kw-axF, .J-N-JX.mYVwse, .J-N-Jo, iframe#help_panel_main_frame {
+  filter: invert(1);
+}
+
+tr.btC, div#\:og, .bBV, .bfXxob.fbhF2  {
+  background-color: rgb(11, 13, 14) !important;
+}
+
+.KA.Kj-JD-Jh, .yawtRb.djlcTc {
+  background-color: rgb(11, 13, 14) !important;
+}
+
+
+.IzuY1c, div#yDmH0d {
+  background: #0b0d0e !important;
+}
+
+.ZWZruf, .BP.AG.J-N-JX {
+  filter: invert(1) !important;
+}
+
+body#yDmH0d, .R6TFwe, .uEzZIb, .pbeTDb, .R6TFwe, .brB-Jz {
+  background-color: rgb(11, 13, 14) !important;
+
+}
+
+.bg {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+input#c0 {
+  color: #fff !important;
+}
+
+.help-panel-header {
+  background-color: rgb(11, 13, 14);
+  box-shadow: none;
+}
+.help-panel-views {
+  background-color: rgb(11, 13, 14);
+  color-scheme: dark;
+}
+
+.aT5-aOt-M {
+  background-image: initial;
+  background-color: rgb(11, 13, 14) !important;
+  border-color: rgba(126, 116, 101, 0.2) !important;
+  box-shadow: rgba(35, 39, 41, 0.3) 0px 1px 2px 0px, rgba(35, 39, 41, 0.15) 0px 2px 6px 2px !important;
+  outline-color: initial;
+}
+
+.bq9.buW {
+  filter: invert(1);
+} 
+
+.O1htCb-H9tDt, .WHwkdf.RU9E7d.SgzFZ {
+    filter: invert(1);
+}
+
+ul.VfPpkd-StrnGf-rymPhb.DMZ54e {
+  background-color: rgb(11, 13, 14) !important;
+  color: #fff !important;
+}
+
+.TO .aHS-aHP .qj {
+}
+
+.VF {
+  background-image: initial;
+  filter: invert(1);
+}
+body.EIlDfe {
+  background-image: initial;
+  background-color: rgb(11, 13, 14)  !important;
+}
+.VI {
+  background-image: initial;
+  background-color: rgb(11, 13, 14) !important;
+}
+.header.Sikpge {
+  border-color: rgb(45, 49, 52) !important;
+  background-color: rgb(11, 13, 14) !important;
+}
+.tDkEBc {
+  background-color: rgb(18, 21, 22) !important;
+}
+
+.tJHJj {
+  background:rgb(11, 13, 14) !important;
+}
+
+img.hRP3bd, .f3n4ge {
+  filter: invert(1) !important;
+}
+
+.WYeHIc {
+  filter: invert(1) !important;
+}
+
+.J-jxwiSc.J-JB-KA, tr.J-JB-KA-JS, th.J-JB-KA-LG, .J-JB-KA-K8 {
+  background-color: rgb(18, 21, 22) !important;
+  color: #fff !important;
+
+}
+
+button.J-JB-KA-Jk.J-JB-KA-bsP, button.J-JB-KA-Jk.J-JB-KA-bsO, button.J-JB-KA-Jk.J-JB-KA-awT-Jk, button.J-JB-KA-Jk.J-JB-KA-K8-Jk {
+  background: transparent !important;
+  color: #fff !important;
+}
+
+.J-JB-KA-K8::before, .J-JB-KA-JB:not(.J-JB-KA-K8):not(.J-JB-KA-KO):hover::before {
+  background-color: rgba(52, 52, 53, 0.8) !important;
+}
+
+
+.J-N, .J-N-Jz, div#\:nx, .mL.f4.J-N-JX, div#\:vr {
+  background: transparent !important;
+}
+.J-M {
+  background: rgb(18, 21, 22) !important;
+}
+
+
+div#\:2cs {
+  background-color: rgb(11, 13, 14) !important;
+}
+
+.msg6026393305677836731 .m_6026393305677836731bg-cover, .msg5915716874261663446 .m_5915716874261663446bg-cover {
+  background: none !important;
+}
+
+.a3s > div > div > div {
+  background: rgb(11, 13, 14) !important;
+  max-width: 100% !important;
+}
+
+
+
+.aO7 > div {
+  background: rgb(11, 13, 14) !important;
+}
+.qdOxv-K0-wGMbrd-Zr > span {
+  color: #fff !important;
+}
+
+.TK:nth-child(2) {
+  background: #fff !important;
+}
+
+#\:lv > div > .qj {
+  filter: invert(1) !important;
+}
+
+/* ---- Gemini side panel ----
+   Gmail forces the LIGHT GM3 palette on the Gemini panel wrapper (.GYfbG),
+   regardless of theme. The whole widget is styled via var(--gm3-sys-color-*)
+   tokens, so re-declaring the palette on the wrapper darkens every descendant
+   without chasing obfuscated per-element classes. Values below are Gmail's own
+   official dark palette (copied from its .ZdZJp dark-theme rule).
+   .MxSLJe / div[aria-label="Gemini"] are the panel itself, included as
+   fallbacks in case Google renames the wrapper class.
+   .eJPjde / .DC5CAd are the "Summarize this email" chip above messages,
+   which sits in a light-palette region and needs the same treatment. */
+.GYfbG, .MxSLJe, div[aria-label="Gemini"], .eJPjde, .DC5CAd {
+  --ae-link-preview-container-color: var(--gm3-sys-color-surface-container-high,#282a2c) !important;
+  --gm3-sys-color-background: #131314 !important;
+  --gm3-sys-color-background-rgb: 19,19,20 !important;
+  --gm3-sys-color-error: #f2b8b5 !important;
+  --gm3-sys-color-error-container: #8c1d18 !important;
+  --gm3-sys-color-error-container-rgb: 140,29,24 !important;
+  --gm3-sys-color-error-rgb: 242,184,181 !important;
+  --gm3-sys-color-inverse-on-surface: #303030 !important;
+  --gm3-sys-color-inverse-on-surface-rgb: 48,48,48 !important;
+  --gm3-sys-color-inverse-primary: #0b57d0 !important;
+  --gm3-sys-color-inverse-primary-rgb: 11,87,208 !important;
+  --gm3-sys-color-inverse-surface: #e3e3e3 !important;
+  --gm3-sys-color-inverse-surface-rgb: 227,227,227 !important;
+  --gm3-sys-color-on-background: #e3e3e3 !important;
+  --gm3-sys-color-on-background-rgb: 227,227,227 !important;
+  --gm3-sys-color-on-error: #601410 !important;
+  --gm3-sys-color-on-error-container: #f9dedc !important;
+  --gm3-sys-color-on-error-container-rgb: 249,222,220 !important;
+  --gm3-sys-color-on-error-rgb: 96,20,16 !important;
+  --gm3-sys-color-on-primary: #062e6f !important;
+  --gm3-sys-color-on-primary-container: #d3e3fd !important;
+  --gm3-sys-color-on-primary-container-rgb: 211,227,253 !important;
+  --gm3-sys-color-on-primary-fixed: #041e49 !important;
+  --gm3-sys-color-on-primary-fixed-rgb: 4,30,73 !important;
+  --gm3-sys-color-on-primary-fixed-variant: #0842a0 !important;
+  --gm3-sys-color-on-primary-fixed-variant-rgb: 8,66,160 !important;
+  --gm3-sys-color-on-primary-rgb: 6,46,111 !important;
+  --gm3-sys-color-on-secondary: #035 !important;
+  --gm3-sys-color-on-secondary-container: #c2e7ff !important;
+  --gm3-sys-color-on-secondary-container-rgb: 194,231,255 !important;
+  --gm3-sys-color-on-secondary-fixed: #001d35 !important;
+  --gm3-sys-color-on-secondary-fixed-rgb: 0,29,53 !important;
+  --gm3-sys-color-on-secondary-fixed-variant: #004a77 !important;
+  --gm3-sys-color-on-secondary-fixed-variant-rgb: 0,74,119 !important;
+  --gm3-sys-color-on-secondary-rgb: 0,51,85 !important;
+  --gm3-sys-color-on-surface: #e3e3e3 !important;
+  --gm3-sys-color-on-surface-rgb: 227,227,227 !important;
+  --gm3-sys-color-on-surface-variant: #c4c7c5 !important;
+  --gm3-sys-color-on-surface-variant-rgb: 196,199,197 !important;
+  --gm3-sys-color-on-tertiary: #0a3818 !important;
+  --gm3-sys-color-on-tertiary-container: #c4eed0 !important;
+  --gm3-sys-color-on-tertiary-container-rgb: 196,238,208 !important;
+  --gm3-sys-color-on-tertiary-fixed: #072711 !important;
+  --gm3-sys-color-on-tertiary-fixed-rgb: 7,39,17 !important;
+  --gm3-sys-color-on-tertiary-fixed-variant: #0f5223 !important;
+  --gm3-sys-color-on-tertiary-fixed-variant-rgb: 15,82,35 !important;
+  --gm3-sys-color-on-tertiary-rgb: 10,56,24 !important;
+  --gm3-sys-color-outline: #8e918f !important;
+  --gm3-sys-color-outline-rgb: 142,145,143 !important;
+  --gm3-sys-color-outline-variant: #444746 !important;
+  --gm3-sys-color-outline-variant-rgb: 68,71,70 !important;
+  --gm3-sys-color-primary: #a8c7fa !important;
+  --gm3-sys-color-primary-container: #0842a0 !important;
+  --gm3-sys-color-primary-container-rgb: 8,66,160 !important;
+  --gm3-sys-color-primary-fixed: #d3e3fd !important;
+  --gm3-sys-color-primary-fixed-dim: #a8c7fa !important;
+  --gm3-sys-color-primary-fixed-dim-rgb: 168,199,250 !important;
+  --gm3-sys-color-primary-fixed-rgb: 211,227,253 !important;
+  --gm3-sys-color-primary-rgb: 168,199,250 !important;
+  --gm3-sys-color-scrim: #000 !important;
+  --gm3-sys-color-scrim-rgb: 0,0,0 !important;
+  --gm3-sys-color-secondary: #7fcfff !important;
+  --gm3-sys-color-secondary-container: #004a77 !important;
+  --gm3-sys-color-secondary-container-rgb: 0,74,119 !important;
+  --gm3-sys-color-secondary-fixed: #c2e7ff !important;
+  --gm3-sys-color-secondary-fixed-dim: #7fcfff !important;
+  --gm3-sys-color-secondary-fixed-dim-rgb: 127,207,255 !important;
+  --gm3-sys-color-secondary-fixed-rgb: 194,231,255 !important;
+  --gm3-sys-color-secondary-rgb: 127,207,255 !important;
+  --gm3-sys-color-shadow: #000 !important;
+  --gm3-sys-color-shadow-rgb: 0,0,0 !important;
+  --gm3-sys-color-surface: #131314 !important;
+  --gm3-sys-color-surface-bright: #37393b !important;
+  --gm3-sys-color-surface-bright-rgb: 55,57,59 !important;
+  --gm3-sys-color-surface-container: #1e1f20 !important;
+  --gm3-sys-color-surface-container-high: #282a2c !important;
+  --gm3-sys-color-surface-container-high-rgb: 40,42,44 !important;
+  --gm3-sys-color-surface-container-highest: #333537 !important;
+  --gm3-sys-color-surface-container-highest-rgb: 51,53,55 !important;
+  --gm3-sys-color-surface-container-low: #1b1b1b !important;
+  --gm3-sys-color-surface-container-low-rgb: 27,27,27 !important;
+  --gm3-sys-color-surface-container-lowest: #0e0e0e !important;
+  --gm3-sys-color-surface-container-lowest-rgb: 14,14,14 !important;
+  --gm3-sys-color-surface-container-rgb: 30,31,32 !important;
+  --gm3-sys-color-surface-dim: #131314 !important;
+  --gm3-sys-color-surface-dim-rgb: 19,19,20 !important;
+  --gm3-sys-color-surface-rgb: 19,19,20 !important;
+  --gm3-sys-color-surface-tint: #d1e1ff !important;
+  --gm3-sys-color-surface-tint-rgb: 209,225,255 !important;
+  --gm3-sys-color-surface-variant: #444746 !important;
+  --gm3-sys-color-surface-variant-rgb: 68,71,70 !important;
+  --gm3-sys-color-tertiary: #6dd58c !important;
+  --gm3-sys-color-tertiary-container: #0f5223 !important;
+  --gm3-sys-color-tertiary-container-rgb: 15,82,35 !important;
+  --gm3-sys-color-tertiary-fixed: #c4eed0 !important;
+  --gm3-sys-color-tertiary-fixed-dim: #6dd58c !important;
+  --gm3-sys-color-tertiary-fixed-dim-rgb: 109,213,140 !important;
+  --gm3-sys-color-tertiary-fixed-rgb: 196,238,208 !important;
+  --gm3-sys-color-tertiary-rgb: 109,213,140 !important;
+}
+
+/* Menus inside the Gemini panel hard-code black text (not tokenized) */
+.GYfbG .tB5Jxf-M-X, .MxSLJe .tB5Jxf-M-X {
+  color: var(--gm3-sys-color-on-surface, #e3e3e3) !important;
+}

--- a/recipes/gmail/darkmode.css
+++ b/recipes/gmail/darkmode.css
@@ -20,11 +20,11 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
 .a98 > a {
   color: blue !important;
 }
-.a98 > *, .a98 *, .a98{
+.a98 > *, .a98 *, .a98 {
   background-color: var(--gm3-sys-color-on-background) !important;   
   color: #fff !important;
 }
-.hP, .gD, .go, .gK  {
+.hP, .gD, .go, .gK {
   color:  #fff !important;;
 }
 .a3s.aiL > div > div > table > tbody, .a3s.aiL > div > table {
@@ -62,22 +62,13 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background-color: var(--gm3-sys-color-on-background);
   color: #fff !important;
 }
-.m_1101107240044101454nl-m-block-table {
-  background-color: var(--gm3-sys-color-on-background);
-}
-.m_-9085597476244977982es-m-p20t {
-  background-color: var(--gm3-sys-color-on-background);
-}
 
-.m_-3410381025534480928es-content {
-  background-color: var(--gm3-sys-color-on-background);
-}
 
 .a3s, .a3s > div, .a3s > * .aiL > * {
   background-color: var(--gm3-sys-color-on-background);
 } 
 
-#loading  {
+#loading {
   background-color: rgb(14, 16, 17) !important;
 }
 .la-k .la-m {
@@ -90,21 +81,7 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
 .roster_comm_link, .la-i > div, .aDG {
   background-color: rgb(14, 16, 17) !important;
 }
-.m_6739384714865278520es-m-txt-c > h1{
-  color: #fff !important; 
-}
-.m_-5899876277505173878tag {
-  background-color:rgb(14, 16, 17)!important;
-  color: #fff !important;
-}
 
-.msg-5476942933920871755, .m_-5476942933920871755bg-cover {
-  background-color:rgb(14, 16, 17)!important;
-}
-.msg8210101856495818180 .m_8210101856495818180bg-cover {
-  background-color:rgb(14, 16, 17)!important;
-
-}
 
 .rPlcIc {
   border: none;
@@ -176,7 +153,7 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background-color: rgb(11, 13, 14);
 }
 
-.gb_Kc.gb_hd, .gb_hd.gb_id, .gb-qe{
+.gb_Kc.gb_hd, .gb_hd.gb_id, .gb-qe {
   background-color: rgb(11, 13, 14) !important;
   color: #fff !important;
 }
@@ -249,9 +226,6 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   color: rgb(196, 192, 186)  !important;
 }
 
-.m_2748637039718987311bg-cover > div {
-  max-width: 100%;
-}
 
 [data-darkreader-inline-bgimage] {
   background-image: none !important;
@@ -292,12 +266,7 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background-color: rgba(108, 108, 108, 0.2) !important;
 }
 
-.msg-7895207889899298162 .m_-7895207889899298162bg-cover, .msg5898900423439880409 .m_5898900423439880409bg-cover, .msg3174298617804948066 .m_3174298617804948066bg-cover, .m_-5635427342892673441bg-cover, .msg-5847429093741280064 .m_-5847429093741280064bg-cover  {
-  background: rgb(15, 17, 18) !important;
-}
-.m_-7895207889899298162bg-cover {
-  background: rgb(15, 17, 18) !important;
-}
+
 .uW2Fw-JD:not(.uW2Fw-JD-ql-aPH) :is(.uW2Fw-bHl,.uW2Fw-bHp,.uW2Fw-bHg) {
   background: rgb(11, 13, 14) !important;
 }
@@ -311,9 +280,6 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background: black;
 }
 
-.AD > *, div#\:rm, div#\:p6, .aYF span {
-  color: #000000 !important;
-}
 
 .ZZ {
   background-color: rgb(27, 27, 27) !important;
@@ -353,7 +319,7 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background-color: rgb(19, 19, 19);
 }
 
-.AD > *, div#\:rm, div#\:p6, .aYF span {
+.AD > *, .aYF span {
   color: rgb(217, 215, 212) !important;
 }
 
@@ -378,21 +344,17 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   background-color: rgb(11, 13, 14) !important;
   color: rgb(196, 192, 186) !important;
 }
-.aoT, div#\:rm {
+.aoT {
   background-color: rgb(11, 13, 14) !important;
   color: rgb(196, 192, 186) !important;
 }
 
-div#\:st {
-  color: rgb(196, 192, 186) !important;
-  filter: invert(1) !important;
-}
 
 tr.J-Kw-axF, .J-N-JX.mYVwse, .J-N-Jo, iframe#help_panel_main_frame {
   filter: invert(1);
 }
 
-tr.btC, div#\:og, .bBV, .bfXxob.fbhF2  {
+tr.btC, .bBV, .bfXxob.fbhF2 {
   background-color: rgb(11, 13, 14) !important;
 }
 
@@ -453,8 +415,6 @@ ul.VfPpkd-StrnGf-rymPhb.DMZ54e {
   color: #fff !important;
 }
 
-.TO .aHS-aHP .qj {
-}
 
 .VF {
   background-image: initial;
@@ -504,7 +464,7 @@ button.J-JB-KA-Jk.J-JB-KA-bsP, button.J-JB-KA-Jk.J-JB-KA-bsO, button.J-JB-KA-Jk.
 }
 
 
-.J-N, .J-N-Jz, div#\:nx, .mL.f4.J-N-JX, div#\:vr {
+.J-N, .J-N-Jz, .mL.f4.J-N-JX {
   background: transparent !important;
 }
 .J-M {
@@ -512,19 +472,10 @@ button.J-JB-KA-Jk.J-JB-KA-bsP, button.J-JB-KA-Jk.J-JB-KA-bsO, button.J-JB-KA-Jk.
 }
 
 
-div#\:2cs {
-  background-color: rgb(11, 13, 14) !important;
-}
-
-.msg6026393305677836731 .m_6026393305677836731bg-cover, .msg5915716874261663446 .m_5915716874261663446bg-cover {
-  background: none !important;
-}
-
 .a3s > div > div > div {
   background: rgb(11, 13, 14) !important;
   max-width: 100% !important;
 }
-
 
 
 .aO7 > div {
@@ -538,9 +489,6 @@ div#\:2cs {
   background: #fff !important;
 }
 
-#\:lv > div > .qj {
-  filter: invert(1) !important;
-}
 
 /* ---- Gemini side panel ----
    Gmail forces the LIGHT GM3 palette on the Gemini panel wrapper (.GYfbG),

--- a/recipes/gmail/darkmode.css
+++ b/recipes/gmail/darkmode.css
@@ -3,7 +3,7 @@
 }
 
 
-.jfk-bubble.gtx-bubble, .captcheck_answer_label > input + img, span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"], span[data-href^="https://www.hcaptcha.com/"] > #icon, img.Wirisformula, .asor_t0, .asor_i1 > img, .asor_i4, .d-Na-Jo.d-Na-N-ax3, .RK-QJ-Jk, .RK-Mo.RK-Qq-LF, #ita-st-id-cs, .d-Na-N-M7-JX.d-Na-J3, .gb_df, img[src$="google_gsuite"], img[src$="profile_mask2.png"], .rY>.sa, .buh, .asor, .mixmax-flyout__wrapper, div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div, form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id]), img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"], div[style$="gm_add_black_24dp.png)"] {
+.jfk-bubble.gtx-bubble, span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"], .asor_t0, .asor_i1 > img, .asor_i4, .d-Na-Jo.d-Na-N-ax3, .RK-QJ-Jk, .RK-Mo.RK-Qq-LF, #ita-st-id-cs, .d-Na-N-M7-JX.d-Na-J3, .gb_df, img[src$="google_gsuite"], img[src$="profile_mask2.png"], .rY>.sa, .buh, .asor, img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"], div[style$="gm_add_black_24dp.png)"] {
   filter: invert(1) !important;
 }
 
@@ -276,7 +276,7 @@ body, div, h1, h2, h3, h4, h5, h6, p, span, tr, td, table {
   border: 2px solid gray;
 }
 
-.tB5Jxf-M-X.tB5Jxf-wdeprb-MD85tf-DKzjMe.tB5Jxf-M-X-ql-aPs.tB5Jxf-M-X-ql-avs-QBLLGd.S8daBe-YPmvEd.S8daBe-uG8BId.O68mGe-M.tB5Jxf-M-X-ql-aLT-Kq-uFfGwd.tB5Jxf-M-X-ql-Kq {
+.tB5Jxf-M-X {
   background: black;
 }
 

--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"


### PR DESCRIPTION
## Description

Adds a `darkmode.css` for the Gmail recipe (it previously had none), providing a full dark theme when the service's dark mode is toggled.

Notable: Google's new **Gemini widget** (side panel + "Summarize this email" chip) forces the light GM3 token palette on its wrappers regardless of theme. Instead of chasing obfuscated per-element classes, this stylesheet re-declares Gmail's own official dark palette (`--gm3-sys-color-*`, copied from Gmail's shipped dark-theme rule) scoped to the Gemini wrappers, so every descendant — including future UI Google adds inside the panel — resolves dark automatically.

Also bumps the recipe version `1.6.3` → `1.6.4`.

## Testing

Verified live against mail.google.com: inbox, email reading view, compose, menus, search, the Gemini side panel, its suggestion chips, the Ask Gemini prompt box, and the summarize chip all render in proper dark colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)