### PR TITLE
Add Path of Exile 2 Trade and poe.ninja recipes

### DIFF
--- a/recipes/poe-ninja/darkmode.css
+++ b/recipes/poe-ninja/darkmode.css
@@ -1,0 +1,1 @@
+/* poe.ninja ships its own dark theme — this file is intentionally minimal. */

--- a/recipes/poe-ninja/icon.svg
+++ b/recipes/poe-ninja/icon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Background -->
+  <rect width="1024" height="1024" rx="120" fill="#0d1117"/>
+  <!-- Outer ring -->
+  <circle cx="512" cy="512" r="440" fill="none" stroke="#4ecca3" stroke-width="16" opacity="0.6"/>
+  <!-- Inner ring -->
+  <circle cx="512" cy="512" r="370" fill="none" stroke="#2a9d7f" stroke-width="5" opacity="0.4"/>
+  <!-- Ninja shuriken / currency orb shape -->
+  <g transform="translate(512,512)">
+    <!-- Four diamond blades rotated -->
+    <polygon points="0,-260 60,-60 0,0 -60,-60" fill="#4ecca3" opacity="0.9"/>
+    <polygon points="260,0 60,60 0,0 60,-60" fill="#38b28e" opacity="0.9"/>
+    <polygon points="0,260 -60,60 0,0 60,60" fill="#4ecca3" opacity="0.9"/>
+    <polygon points="-260,0 -60,-60 0,0 -60,60" fill="#38b28e" opacity="0.9"/>
+    <!-- Diagonal blades -->
+    <polygon points="0,-260 60,-60 0,0 -60,-60" fill="#4ecca3" opacity="0.5" transform="rotate(45)"/>
+    <polygon points="260,0 60,60 0,0 60,-60" fill="#38b28e" opacity="0.5" transform="rotate(45)"/>
+    <polygon points="0,260 -60,60 0,0 60,60" fill="#4ecca3" opacity="0.5" transform="rotate(45)"/>
+    <polygon points="-260,0 -60,-60 0,0 -60,60" fill="#38b28e" opacity="0.5" transform="rotate(45)"/>
+    <!-- Centre orb -->
+    <circle cx="0" cy="0" r="80" fill="#0d1117" stroke="#4ecca3" stroke-width="10"/>
+    <circle cx="0" cy="0" r="45" fill="#4ecca3" opacity="0.8"/>
+  </g>
+  <!-- poe.ninja text -->
+  <text x="512" y="800" font-family="Georgia, serif" font-size="90" font-weight="bold" fill="#4ecca3" text-anchor="middle" letter-spacing="4">poe.ninja</text>
+</svg>

--- a/recipes/poe-ninja/index.js
+++ b/recipes/poe-ninja/index.js
@@ -1,0 +1,1 @@
+module.exports = Ferdium => Ferdium;

--- a/recipes/poe-ninja/package.json
+++ b/recipes/poe-ninja/package.json
@@ -1,0 +1,9 @@
+{
+  "id": "poe-ninja",
+  "name": "poe.ninja",
+  "version": "1.0.0",
+  "license": "MIT",
+  "config": {
+    "serviceURL": "https://poe.ninja"
+  }
+}

--- a/recipes/poe-ninja/webview.js
+++ b/recipes/poe-ninja/webview.js
@@ -1,0 +1,3 @@
+module.exports = Ferdium => {
+  // poe.ninja is a read-only economy tracker — no badge/notification logic needed.
+};

--- a/recipes/poe2-trade/darkmode.css
+++ b/recipes/poe2-trade/darkmode.css
@@ -1,0 +1,2 @@
+/* Path of Exile 2 Trade already supports its own dark theme.
+   This file is intentionally minimal. */

--- a/recipes/poe2-trade/icon.svg
+++ b/recipes/poe2-trade/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Background -->
+  <rect width="1024" height="1024" rx="120" fill="#1a0d00"/>
+  <!-- Decorative outer ring -->
+  <circle cx="512" cy="512" r="440" fill="none" stroke="#c89b3c" stroke-width="18" opacity="0.7"/>
+  <!-- Inner ring -->
+  <circle cx="512" cy="512" r="370" fill="none" stroke="#8b5e1a" stroke-width="6" opacity="0.5"/>
+  <!-- Stylised PoE gem / orb shape -->
+  <polygon points="512,160 640,340 810,380 690,530 720,710 512,620 304,710 334,530 214,380 384,340" fill="#2a1500" stroke="#c89b3c" stroke-width="12" stroke-linejoin="round"/>
+  <!-- Inner gem facets -->
+  <polygon points="512,240 612,380 512,480 412,380" fill="#c89b3c" opacity="0.25"/>
+  <polygon points="512,480 612,380 710,500 512,620" fill="#a07020" opacity="0.3"/>
+  <polygon points="512,480 412,380 314,500 512,620" fill="#7a5010" opacity="0.3"/>
+  <!-- Trade arrows (two crossing arrows in centre) -->
+  <g fill="#e8c060" opacity="0.95">
+    <!-- Arrow right -->
+    <polygon points="420,490 580,490 580,470 620,512 580,554 580,534 420,534" />
+    <!-- Arrow left (offset) -->
+    <polygon points="604,490 444,490 444,470 404,512 444,554 444,534 604,534" opacity="0.5"/>
+  </g>
+  <!-- PoE2 text -->
+  <text x="512" y="760" font-family="Georgia, serif" font-size="110" font-weight="bold" fill="#c89b3c" text-anchor="middle" letter-spacing="8">PoE2</text>
+</svg>

--- a/recipes/poe2-trade/index.js
+++ b/recipes/poe2-trade/index.js
@@ -1,0 +1,1 @@
+module.exports = Ferdium => Ferdium;

--- a/recipes/poe2-trade/package.json
+++ b/recipes/poe2-trade/package.json
@@ -1,0 +1,9 @@
+{
+  "id": "poe2-trade",
+  "name": "Path of Exile 2 Trade",
+  "version": "1.0.0",
+  "license": "MIT",
+  "config": {
+    "serviceURL": "https://www.pathofexile.com/trade2/exchange/poe2/Runes%20of%20Aldur"
+  }
+}

--- a/recipes/poe2-trade/webview.js
+++ b/recipes/poe2-trade/webview.js
@@ -1,0 +1,4 @@
+module.exports = Ferdium => {
+  // Path of Exile 2 Trade - no unread badge logic needed for a trade site
+  // The page is a static trading exchange; we just ensure it loads cleanly.
+};


### PR DESCRIPTION
## New Recipes: Path of Exile 2 Trade + poe.ninja

Adds two Ferdium recipes for Path of Exile tooling.

---

### 1. Path of Exile 2 Trade

- **ID:** `poe2-trade`
- **Service URL:** `https://www.pathofexile.com/trade2/exchange/poe2/Runes%20of%20Aldur`
- **Icon:** Custom SVG in PoE2 gold-and-dark aesthetic
- **Dark mode:** Minimal `darkmode.css` (site ships its own dark theme)
- **Badge notifications:** Not applicable for a trade/exchange page

---

### 2. poe.ninja

- **ID:** `poe-ninja`
- **Service URL:** `https://poe.ninja`
- **Icon:** Custom SVG — dark background with teal shuriken/orb motif matching poe.ninja's colour palette
- **Dark mode:** Minimal `darkmode.css` (site ships its own dark theme)
- **Badge notifications:** Not applicable for a read-only economy tracker

---

### Files (each recipe)
- `package.json` — service metadata and URL
- `index.js` — passes through Ferdium class
- `webview.js` — stub (no badge counting needed)
- `darkmode.css` — intentionally minimal
- `icon.svg` — 1024×1024 square SVG

Tested locally in Ferdium by loading both dev recipes.