### PR TITLE
Gotify: badge always shows 1

### DIFF
--- a/recipes/gotify/badge.js
+++ b/recipes/gotify/badge.js
@@ -1,0 +1,61 @@
+(() => {
+  if (window.gotifyFerdiumBadgeInjected) {
+    return;
+  }
+
+  window.gotifyFerdiumBadgeInjected = true;
+
+  const sendBadge = count => {
+    window.dispatchEvent(
+      new CustomEvent('gotify-ferdium-badge', {
+        detail: { count },
+      }),
+    );
+  };
+
+  const findReactFiber = element => {
+    const key = Object.keys(element).find(name =>
+      name.startsWith('__reactFiber$'),
+    );
+
+    return key ? element[key] : null;
+  };
+
+  const isMessageList = data =>
+    Array.isArray(data) &&
+    data.every(
+      message =>
+        message &&
+        typeof message.id === 'number' &&
+        typeof message.message === 'string' &&
+        typeof message.appid === 'number',
+    );
+
+  const getLoadedMessageCount = () => {
+    const root = document.querySelector('#messages');
+
+    if (!root) {
+      return 0;
+    }
+
+    // A Fiber's `return` property points to its parent Fiber. React sets it to
+    // null when the parent chain ends, so walk up the tree until that point.
+    let currentFiber = findReactFiber(root);
+
+    while (currentFiber !== null) {
+      const data = currentFiber.memoizedProps?.data;
+
+      if (isMessageList(data) && data.length > 0) {
+        return data.length;
+      }
+
+      currentFiber = currentFiber.return ?? null;
+    }
+
+    return 0;
+  };
+
+  window.addEventListener('gotify-ferdium-poll', () => {
+    sendBadge(getLoadedMessageCount());
+  });
+})();

--- a/recipes/gotify/package.json
+++ b/recipes/gotify/package.json
@@ -1,12 +1,12 @@
 {
   "id": "gotify",
   "name": "Gotify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,
-    "hasDirectMessages": false,
-    "hasIndirectMessages": true,
+    "hasDirectMessages": true,
+    "hasIndirectMessages": false,
     "hasCustomUrl": true
   }
 }

--- a/recipes/gotify/webview.js
+++ b/recipes/gotify/webview.js
@@ -1,16 +1,12 @@
-function _interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
-}
-
-const _path = _interopRequireDefault(require('path'));
+const path = require('path');
 
 module.exports = Ferdium => {
-  const getMessages = () => {
-    const count = document.querySelectorAll('#messages').length;
+  window.addEventListener('gotify-ferdium-badge', event => {
+    Ferdium.setBadge(event.detail?.count || 0, 0);
+  });
 
-    Ferdium.setBadge(count);
-  };
-
-  Ferdium.loop(getMessages);
-  Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdium.injectJSUnsafe(path.join(__dirname, 'badge.js'));
+  Ferdium.loop(() => {
+    window.dispatchEvent(new CustomEvent('gotify-ferdium-poll'));
+  });
 };


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Closes https://github.com/ferdium/ferdium-app/issues/2459 

<!-- Describe your changes in detail. -->

Gotify's existing recipe sets the badge count to reflect the count of `#messages`. That is a container only, and individual messages are children of that container. Because of this, the badge count is always 1.

Gotify uses React Fiber, and will only render DOM elements that are visible. Relying on visible DOM elements is inconsistent. If you have 50 messages, but only 10 are visible, the logic would show 10 instead of the real 50.

This implementation isn't perfect: this only reports the number of messages loaded by the Gotify client instead of using a direct API integration. Adding an API integration would require setting up an API key, or injecting into existing XHR requests, which feels a bit hacky. I think this loaded messages approach will be accurate more often than not.

This could become brittle if Gotify changes front-end frameworks, or even during major version upgrades of the front-end framework used by Gotify. I think this is a fair tradeoff.

This was manually tested in Ferdium 7.1.2 with 86 loaded messages, 0 messages, sending additional high-priority Gotify notifications. lint, reformat-files, and package all pass.