### PR TITLE
Restore Discord desktop notifications

### DIFF
--- a/recipes/discord/notification-compatibility.js
+++ b/recipes/discord/notification-compatibility.js
@@ -1,0 +1,70 @@
+const runtimes = [];
+let observedChunkPush;
+let captureCount = 0;
+
+const captureRuntimes = () => {
+  const chunks = window.webpackChunkdiscord_app;
+  if (!Array.isArray(chunks) || chunks.push === observedChunkPush) return;
+
+  observedChunkPush = chunks.push;
+  captureCount += 1;
+  // Discord chains private Rspack runtimes. Match exports, not module IDs.
+  chunks.push([
+    [`ferdium-notification-compatibility-${Date.now()}-${captureCount}`],
+    {},
+    require => {
+      if (!runtimes.includes(require)) runtimes.push(require);
+    },
+  ]);
+};
+
+const findNotificationSettingsStore = () => {
+  captureRuntimes();
+  const stores = [];
+
+  for (const runtimeRequire of runtimes) {
+    for (const module of Object.values(runtimeRequire.c || {})) {
+      const exports = module?.exports;
+      const candidates = [
+        exports,
+        ...(exports && typeof exports === 'object'
+          ? Object.values(exports)
+          : []),
+      ];
+
+      for (const candidate of candidates) {
+        if (
+          candidate?.constructor?.displayName === 'NotificationSettingsStore' &&
+          typeof candidate.getDesktopType === 'function' &&
+          typeof candidate.getUserAgnosticState === 'function' &&
+          !stores.includes(candidate)
+        ) {
+          stores.push(candidate);
+        }
+      }
+    }
+  }
+
+  return stores.length === 1 ? stores[0] : null;
+};
+
+const enableNotifications = () => {
+  const store = findNotificationSettingsStore();
+  if (!store) return false;
+
+  // Discord defaults to NEVER without DiscordNative and returns before Ferdium's Notification shim.
+  const state = store.getUserAgnosticState();
+  if (store.getDesktopType() === 'NEVER' && state?.desktopType === 'NEVER') {
+    state.desktopType = 'ALL';
+  }
+  return true;
+};
+
+if (!enableNotifications()) {
+  const startedAt = Date.now();
+  const interval = setInterval(() => {
+    if (enableNotifications() || Date.now() - startedAt >= 30_000) {
+      clearInterval(interval);
+    }
+  }, 500);
+}

--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discord.com/app",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -24,6 +24,9 @@ module.exports = (Ferdium, settings) => {
   Ferdium.loop(getMessages);
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdium.injectJSUnsafe(
+    _path.default.join(__dirname, 'notification-compatibility.js'),
+  );
 
   // TODO: See how this can be moved into the main ferdium app and sent as an ipc message for opening with a new window or same Ferdium recipe's webview based on user's preferences
   document.addEventListener(


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Discord's desktop notifications haven't worked consistently since around 2022.
Closes https://github.com/ferdium/ferdium-app/issues/982
Closes https://github.com/ferdium/ferdium-app/issues/2377

After digging in some more, it appears Discord's internals include a `desktopType` setting which can either be `ALL` or `NEVER`. This is set to `NEVER` when `DiscordNative` is unavailable, as is the case in Ferdium.  When `desktopType` is set to `NEVER`, Discord's notification flow will stop after playing the sound, and never sends the desktop notification. This matches the behavior described in both of the linked issues.

This fix is a bit of a hack. We're messing with Discord's internals, and changing its internal state. At the end of the day, it's really just setting `desktopType` to `ALL` so that the entire notification flow executes inside discord. By patching that, the notifications bubble up through Discord to Ferdium's notification shim as expected, and notifications honor both Discord's notification preferences alongside Ferdium's.

I did my manual testing in Ferdium 7.1.2 on linux, I did not explicitly test on MacOS or Windows. Best I can tell, there's no OS-specific code so I expect it should continue to work cross-platform.