### PR TITLE
fix(gotify): badge stuck at 1 even with no messages

### DIFF
--- a/recipes/gotify/package.json
+++ b/recipes/gotify/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gotify",
   "name": "Gotify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "config": {
     "hasNotificationSound": true,

--- a/recipes/gotify/webview.js
+++ b/recipes/gotify/webview.js
@@ -6,9 +6,14 @@ const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
   const getMessages = () => {
-    const count = document.querySelectorAll('#messages').length;
+    // #messages is the (always-present) list container, not the messages
+    // themselves, so its presence alone can't be used as the badge count.
+    // The "Delete All" button is disabled exactly when the list is empty,
+    // so its disabled state tells us whether there are unread messages.
+    const deleteAllButton = document.querySelector('#delete-all');
+    const hasMessages = !!deleteAllButton && !deleteAllButton.disabled;
 
-    Ferdium.setBadge(count);
+    Ferdium.setBadge(hasMessages ? 1 : 0);
   };
 
   Ferdium.loop(getMessages);


### PR DESCRIPTION
The Gotify recipe's badge counter never goes back to 0:

```js
const count = document.querySelectorAll('#messages').length;
Ferdium.setBadge(count);
```

`#messages` is the id of Gotify's message-list container (a
`react-virtuoso` wrapper, see
[Messages.tsx](https://github.com/gotify/server/blob/master/ui/src/message/Messages.tsx#L100)),
not the individual messages. That container is always present once the
page has loaded, so `querySelectorAll('#messages').length` is `1` the
moment the Gotify UI mounts — regardless of whether there are 0 or 50
messages. Deleting all messages never clears the badge, because the
container element itself never disappears.

Note that the message list is virtualized, so counting *child* elements
of `#messages` isn't reliable either — only the currently visible items
exist in the DOM.

Instead, this uses the `#delete-all` button, which Gotify's own UI
already disables exactly when the message list is empty
(`disabled={!hasMessages}` in Messages.tsx). Reading its `disabled`
state gives an accurate empty/non-empty signal without depending on
virtualization internals.

`Ferdium.setBadge(hasMessages ? 1 : 0)` keeps the same direct-count
argument the original recipe used, so visible behavior is unchanged
apart from the fix itself (an earlier version of this PR tried the
indirect-count argument to match this recipe's `hasIndirectMessages`
config, but that didn't surface a badge at all in manual testing).

Version bumped 1.1.1 → 1.1.2 per the recipe update guide.

## Test plan
- [x] Loaded the updated recipe locally via `%appdata%/Ferdium/recipes/gotify` on Windows, reloaded Ferdium with Ctrl+R
- [x] Confirmed badge shows when Gotify has ≥1 message
- [x] Confirmed badge clears after clicking "Delete All" / deleting the last message
- [ ] `pnpm lint:fix && pnpm reformat-files && pnpm package` run clean
