### PR TITLE
Fix Instagram login on macOS Tahoe

### DIFF
--- a/recipes/instagram/index.js
+++ b/recipes/instagram/index.js
@@ -2,7 +2,12 @@ module.exports = Ferdium =>
   class Instagram extends Ferdium {
     overrideUserAgent() {
       return window.navigator.userAgent
-        .replaceAll(/(Ferdium|Electron)\/\S+ \([^)]+\)/g, '')
+        .replace(
+          /\(Macintosh; Apple macOS [^)]+\)/,
+          '(Macintosh; Intel Mac OS X 10_15_7)',
+        )
+        .replace(/\b(?:Ferdium|Electron)\/\S+/g, '')
+        .replace(/\s{2,}/g, ' ')
         .trim();
     }
   };

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the recipe package version according to the [Updating guide](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number).

#### Description of Change

Fixes ferdium/ferdium-app#2441.

Instagram rejects Ferdium's current macOS Tahoe User-Agent and displays "Page is not available" instead of the login page. The existing cleanup only removes `Ferdium` or `Electron` when the product token is followed by a parenthesized suffix, which does not match the current User-Agent layout.

This change:

- normalizes Ferdium's `Apple macOS` platform token to the conventional macOS browser token;
- removes `Ferdium` and `Electron` product tokens independently of their position;
- collapses whitespace left by those removals; and
- bumps the Instagram recipe from `2.5.4` to `2.5.5` so clients receive the update.

Thanks to @hsuchil for identifying and sharing the working User-Agent normalization in the issue.

#### Verification

- Reproduced the failure with the original recipe using a Ferdium 7.1.2 / Electron 37.2.6-style macOS Tahoe User-Agent.
- Verified the same regression harness returns a clean browser User-Agent after the change.
- Ran the repository-required `pnpm validate` with Node 22.18.0 and pnpm 10.14.0.
- Manually verified in Ferdium 7.1.2 on macOS Tahoe 26.5.2 arm64 that Instagram now reaches the login form after a full app restart.
