### PR TITLE
Update webview.js to work with new Google Chat changes

### DIFF
--- a/recipes/hangoutschat/package.json
+++ b/recipes/hangoutschat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangoutschat",
   "name": "Hangouts Chat",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "aliases": [
     "google-chat",

--- a/recipes/hangoutschat/webview.js
+++ b/recipes/hangoutschat/webview.js
@@ -16,7 +16,7 @@ module.exports = Ferdium => {
 
   // div definition of the text element listing the number of unread "Direct messages"
   const directMessageSelector = 'div[data-section-type="1"] div.TeR7uc';
-  
+
   // div definition of the text element listing the number of unread "Spaces" messages
   const indirectMessageSelector = 'div[data-section-type="2"] div.TeR7uc';
 
@@ -26,9 +26,7 @@ module.exports = Ferdium => {
     let indirectCount;
 
     // get unread direct messages count
-	const directCountSelector = document.querySelector(
-      directMessageSelector,
-    );
+    const directCountSelector = document.querySelector(directMessageSelector);
     if (directCountSelector) {
       directCount = Number(directCountSelector.textContent);
     }

--- a/recipes/hangoutschat/webview.js
+++ b/recipes/hangoutschat/webview.js
@@ -14,20 +14,26 @@ module.exports = Ferdium => {
       'https://accounts.google.com/AccountChooser?continue=https://chat.google.com/?referrer=2';
   }
 
-  // class corresponding to the bold text that is visible for room messages
-  const indirectMessageSelector = 'div.V6.CL.V2.X9.Y2 span.akt span.XU';
+  // div definition of the text element listing the number of unread "Direct messages"
+  const directMessageSelector = 'div[data-section-type="1"] div.TeR7uc';
+  
+  // div definition of the text element listing the number of unread "Spaces" messages
+  const indirectMessageSelector = 'div[data-section-type="2"] div.TeR7uc';
 
   const getMessages = () => {
     // get unread direct messages
     let directCount;
     let indirectCount;
 
-    // get unread messages count
-    directCount = document.querySelectorAll(
-      'link[href^="https://ssl.gstatic.com/ui/v1/icons/mail/images/favicon_chat_new_notif_"][href$=".ico"]',
-    ).length;
+    // get unread direct messages count
+	const directCountSelector = document.querySelector(
+      directMessageSelector,
+    );
+    if (directCountSelector) {
+      directCount = Number(directCountSelector.textContent);
+    }
 
-    // get unread indirect messages
+    // get unread indirect (spaces) messages
     const indirectCountSelector = document.querySelector(
       indirectMessageSelector,
     );


### PR DESCRIPTION
Google has updated Hangouts/Google Chat over the last few years and changed the favicon that is used, so this old way of checking for new messages no longer works. I updated the method to use a different method because:

1. Favicon isn't granular enough to distinguish between "direct" and "indirect" message counts, and;
2. given that the URL for the favicon changed _twice_ within the span of a month, a more stable structural definition of what the page uses to indicate the unread messages is probably warranted.

This new method uses the elements in the page that actually list the unread messages in "Direct messages" and in "Spaces" and use those for the direct message count and indirect message count, respectively.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

<!-- Describe your changes in detail. -->
