### PR TITLE
fix(google-calendar): restore the window.alert modal override

### DIFF
--- a/recipes/google-calendar/package.json
+++ b/recipes/google-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "google-calendar",
   "name": "Google Calendar",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "license": "MIT",
   "aliases": [
     "google-calendar",

--- a/recipes/google-calendar/webview-unsafe.js
+++ b/recipes/google-calendar/webview-unsafe.js
@@ -26,9 +26,21 @@ const hideModal = () => {
 const createModal = () => {
   const modalDialog = document.createElement('div');
   modalDialog.setAttribute('id', 'franz-modal');
-  modalDialog.textContent =
-    '<div class="modal-content"><span class="close">&times;</span><p></p></div>';
-  modalDialog.querySelector('.close').addEventListener('click', hideModal);
+
+  // Built up with DOM calls instead of a markup string: calendar.google.com
+  // sends `require-trusted-types-for 'script'`, so assigning innerHTML throws.
+  const content = document.createElement('div');
+  content.classList.add('modal-content');
+
+  const close = document.createElement('span');
+  close.classList.add('close');
+  close.textContent = '×';
+  close.addEventListener('click', hideModal);
+
+  const message = document.createElement('p');
+
+  content.append(close, message);
+  modalDialog.append(content);
 
   return modalDialog;
 };

--- a/recipes/google-calendar/webview.js
+++ b/recipes/google-calendar/webview.js
@@ -15,12 +15,27 @@ module.exports = Ferdium => {
   }
 
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
-  Ferdium.injectCSS(
-    'https://cdn.statically.io/gh/ferdium/ferdium-recipes/main/recipes/google-calendar/calendar.css',
-  );
-  Ferdium.injectJSUnsafe(
-    'https://cdn.statically.io/gh/ferdium/ferdium-recipes/main/recipes/google-calendar/webview-unsave.js',
-  );
+  // calendar.css is linked rather than passed to Ferdium.injectCSS, because
+  // injectCSS fills a <style> element via innerHTML, which calendar.google.com
+  // rejects under `require-trusted-types-for 'script'`. Same approach as the
+  // darkmode.css workaround below.
+  const calendarCssId = 'cssFranzModal';
+  if (!document.querySelector(`#${calendarCssId}`)) {
+    const head = document.querySelectorAll('head')[0];
+    const link = document.createElement('link');
+    link.id = calendarCssId;
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href =
+      'https://cdn.statically.io/gh/ferdium/ferdium-recipes/main/recipes/google-calendar/calendar.css';
+    link.media = 'all';
+    head.append(link);
+  }
+
+  // Injected from disk: injectJSUnsafe only reads local files, handing the
+  // source to webview.executeJavaScript (which page CSP does not apply to).
+  // Passing it a URL silently injected nothing at all.
+  Ferdium.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
 
   Ferdium.handleDarkMode(isEnabled => {
     const cssId = 'cssDarkModeWorkaround';


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) (2.4.5 → 2.4.6)

#### Description of Change

The `window.alert` → in-page modal override in this recipe has not run since #402 (Aug 2023). Google Calendar reminders set to **Alerts** therefore fall through to the real `window.alert()`, which Electron renders as a **native OS dialog** instead of the `#franz-modal` this recipe ships.

There are two independent defects, and fixing either alone is not enough.

**1. `injectJSUnsafe` was given a URL, and it only reads local files.**

`RecipeWebview.injectJSUnsafe()` gates on `existsSync(file)` and then `readFileSync`s it, so an `http(s)://` argument is silently discarded — the only trace is a `Script not found` line behind the `Ferdium:Plugin:RecipeWebview` debug namespace. `git log -S` confirms it has never had URL support in any revision. The URL in #402 was also typo'd as `webview-unsave.js` (the file on disk is `webview-unsafe.js`), so it 404s:

```console
$ curl -sLo /dev/null -w '%{http_code}\n' https://cdn.statically.io/gh/ferdium/ferdium-recipes/main/recipes/google-calendar/webview-unsave.js
404
```

Injecting from disk is safe with respect to the CSP problem that motivated #402: `inject-js-unsafe` is handed to `webview.executeJavaScript()` (`src/models/Service.ts`), which the page's CSP does not govern. So this does not reintroduce the TrustedTypes error from ferdium-app#1086.

**2. `createModal()` threw before the override was ever installed.**

It assigned a *markup string* to `textContent` where it meant `innerHTML`, so `querySelector('.close')` returned `null`:

```
TypeError: Cannot read properties of null (reading 'addEventListener')
    at createModal (webview-unsafe.js:31:38)
```

I rebuilt it with DOM calls rather than switching to `innerHTML`, because `calendar.google.com` sends `require-trusted-types-for 'script'` and would reject an `innerHTML` assignment as well.

**Also:** `calendar.css` (which styles `#franz-modal`) now attaches via a `<link>` element instead of `Ferdium.injectCSS()`. `injectCSS` fills a `<style>` element via `innerHTML`, which *does* hit that TrustedTypes restriction — this is the same reason the `darkmode.css` workaround in this file already uses a `<link>`.

#### Testing

- `pnpm validate` passes (411 recipes packaged, 0 unsuccessful).
- Exercised `webview-unsafe.js` against a DOM stub to confirm the actual behaviour rather than just the syntax: `window.alert(...)` now populates and opens the modal, the badge increments, and the close button clears and hides it. The same harness reproduces the `TypeError` above against the current `main`.

For reference, this surfaced while diagnosing ferdium-app#435 — on a snap install those native dialogs render every glyph as a box, so the reminder text is completely unreadable. That font bug is separate ([details here](https://github.com/ferdium/ferdium-app/issues/435#issuecomment-5189207305)); this PR is about the reminder not going through the native dialog in the first place.
