### PR TITLE
Fix the unread count for office365-owa recipe

### DIFF
--- a/recipes/office365-owa/package.json
+++ b/recipes/office365-owa/package.json
@@ -1,7 +1,7 @@
 {
   "id": "office365-owa",
   "name": "Office 365 Outlook",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "license": "MIT",
   "aliases": [
     "live.com",

--- a/recipes/office365-owa/webview.js
+++ b/recipes/office365-owa/webview.js
@@ -68,12 +68,14 @@ module.exports = (Ferdium, settings) => {
       );
     } else {
       // new app
+      indirectUnreadCount = collectCounts(
+        'div[role=tree] > div:nth-of-type(2) > div[role=group] > span',
+      ); // groups
       directUnreadCount =
         settings.onlyShowFavoritesInUnreadCount === true
-          ? collectCounts('div[role=tree]:nth-child(2)')
-          : collectCounts('div[role=tree]:nth-child(1)');
-
-      indirectUnreadCount = collectCounts('div[role=tree]:nth-child(4)'); // groups
+          ? collectCounts('div[role=tree] > div:nth-of-type(1)')
+          : collectCounts('div[role=tree] > div:nth-of-type(2)') -
+            indirectUnreadCount;
     }
 
     Ferdium.setBadge(directUnreadCount, indirectUnreadCount);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Fixes the Outlook unread email count:
- fix double-counting unread from favorites
- fix "Only show Favorites" showing 0 unread

Fixes issues from closed PRs https://github.com/ferdium/ferdium-recipes/pull/640 and https://github.com/ferdium/ferdium-recipes/pull/644.

Tested a few scenarios
- onlyShowFavoritesInUnreadCount enabled/disabled
- Unread messages from groups not counted in `directUnreadCount`
- Favorites hidden in Outlook: "Only show Favorites" stops working but otherwise still works correctly