### PR TITLE
fix(hangouts): read the unread count from the shortcut rail

### DIFF
--- a/recipes/hangouts/package.json
+++ b/recipes/hangouts/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangouts",
   "name": "Google Chat",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com/chat/",

--- a/recipes/hangouts/webview.js
+++ b/recipes/hangouts/webview.js
@@ -6,15 +6,22 @@ const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
   const getMessages = () => {
-    // Google Chat publishes its unread total on the shortcut rail's
-    // accessibility label, e.g. "Home shortcut, 3 unread messages", and drops
-    // the number entirely when nothing is unread. The class and jsname
-    // attributes around it are obfuscated and rotate, but data-shortcut-type
-    // is stable: 1 is Home, which covers both direct messages and spaces.
-    const home = document.querySelector('[data-shortcut-type="1"]');
-    const label = home ? home.getAttribute('aria-label') : '';
-    const unread = label ? label.match(/\d+/) : null;
-    const count = unread ? Ferdium.safeParseInt(unread[0]) : 0;
+    // Google Chat puts the unread total on the shortcut rail's accessibility
+    // label, e.g. "Home shortcut, 3 unread messages", and drops the number
+    // when nothing is unread. The classes and jsnames around it rotate, but
+    // data-shortcut-type is stable: 1 is Home, covering both DMs and spaces.
+    const homeElement = document.querySelector('[data-shortcut-type="1"]');
+    const label = homeElement?.getAttribute('aria-label');
+    let count;
+
+    if (label) {
+      const match = label.match(/\d+/);
+      count = match ? Ferdium.safeParseInt(match[0]) : 0;
+    } else {
+      // No rail to read from: count the rendered rows instead. That
+      // undercounts, since the roster is virtualised, but beats reporting zero.
+      count = document.querySelectorAll('span[data-is-unread="true"]').length;
+    }
 
     // set Ferdium badge
     Ferdium.setBadge(count);

--- a/recipes/hangouts/webview.js
+++ b/recipes/hangouts/webview.js
@@ -6,8 +6,15 @@ const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
   const getMessages = () => {
-    // get unread messages
-    let count = document.querySelectorAll('span[data-is-unread="true"]').length;
+    // Google Chat publishes its unread total on the shortcut rail's
+    // accessibility label, e.g. "Home shortcut, 3 unread messages", and drops
+    // the number entirely when nothing is unread. The class and jsname
+    // attributes around it are obfuscated and rotate, but data-shortcut-type
+    // is stable: 1 is Home, which covers both direct messages and spaces.
+    const home = document.querySelector('[data-shortcut-type="1"]');
+    const label = home ? home.getAttribute('aria-label') : '';
+    const unread = label ? label.match(/\d+/) : null;
+    const count = unread ? Ferdium.safeParseInt(unread[0]) : 0;
 
     // set Ferdium badge
     Ferdium.setBadge(count);


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number)

#### Description of Change

Follow-up to #701. That PR moved the badge onto `span[data-is-unread="true"]`, which is a real improvement over the rotating `span[jsname=DW2nlb]` it replaced, but the attribute only exists while the unread conversation is rendered in the roster. When it is not, the selector matches nothing and `setBadge(0)` runs on every tick — so the badge is unreliable rather than plainly broken, which makes it easy to miss in testing.

Measured live against `chat.google.com` in two signed-in Google Chat services, both probes in a single evaluation so the numbers describe the same instant. Each account genuinely had **one** unread message:

| service | ground truth | `span[data-is-unread="true"]` matches |
| --- | --- | --- |
| A | 1 unread | **0** |
| B | 1 unread | 1 |

Same recipe, same moment, same true count, two different answers. In Ferdium itself, running the current 1.5.2, three of four services showed a badge; the Chat service that should have shown `1` showed nothing.

This PR reads the total off the shortcut rail instead:

```js
const home = document.querySelector('[data-shortcut-type="1"]');
const label = home ? home.getAttribute('aria-label') : '';
const unread = label ? label.match(/\d+/) : null;
const count = unread ? Ferdium.safeParseInt(unread[0]) : 0;
```

Google Chat writes the total into that element's accessibility label — `"Home shortcut, 3 unread messages"` — and omits the number entirely when nothing is unread, so it reports the total Chat itself computes for Home, no matter what the roster has rendered. Worth noting that Chat publishes this number through the accessibility layer rather than drawing it on screen in this layout, so the badge can legitimately show a count with no visibly unread row on the page.

Two properties make it a better anchor than what came before:

- `data-shortcut-type` is semantic, not generated — `1` Home, `2` Mentions, `3` Starred. The obfuscated `class` and `jsname` attributes around it are what rotated and broke `span[jsname=DW2nlb]`.
- Pulling digits out of the label instead of matching its English text means it does not need a per-locale word list to keep working in other UI languages.

**Verification.** Ferdium 7.1.2 on macOS (Apple Silicon), two signed-in Google Chat services, A/B tested by swapping the recipe in place and restarting:

| recipe | badges rendered in the sidebar |
| --- | --- |
| 1.5.2 | `1, 13, 1` — one Chat service missing |
| this PR | `1, 1, 13, 1` — both Chat services badged |

Each badge matched the count that account's web UI reported at the same instant. `pnpm validate` passes: 437 recipes packaged, 0 unsuccessful.

**Possible follow-ups**, left out to keep this focused:

- `data-shortcut-type="2"` carries the Mentions subtotal, so the recipe could split direct from indirect via `setBadge(mentions, total - mentions)` if `hasIndirectMessages` were declared.
- The separate `hangoutschat` recipe scrapes `div[data-section-type] div.TeR7uc`, which looks like it has the same class-rotation exposure. I have not tested it.

#### Known limitation

Reading the aggregate means inheriting whatever Google puts in it, including when Google gets it wrong. I hit exactly that on a consumer `@gmail.com` account while testing: the Home label reported `1 unread message` while three independent signals all said zero —

- `[data-is-unread="true"]` matched nothing across 56 rendered rows,
- no conversation was rendered in the unread font weight,
- and Chat's **own** unread filter, switched on, returned an empty list.

The count survived a full reload, so it is server-side state rather than a stale client. The badge therefore sat at 1 with nothing to open.

That is a real trade-off against the previous approach, which counts rendered rows and would have shown 0 here. It is worth naming rather than hiding, but I do not think it changes the verdict: counting rendered rows silently misses genuinely unread conversations, which is the failure users actually notice and report, while this failure mode is Google disagreeing with itself and shows up identically in Chat's own UI.
