### PR TITLE
Fix Gmail unread badge for accounts with Google Chat enabled

### DIFF
--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://mail.google.com"

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -49,7 +49,7 @@ module.exports = Ferdium => {
     if (spaceAndChatBadges.length > 0) {
       const arr = [...spaceAndChatBadges];
       const spaceAndChatCount = arr.reduce(
-        (acc, e) => Ferdium.safeParseInt(e.getInnerHTML()) + acc,
+        (acc, e) => Ferdium.safeParseInt(e.textContent) + acc,
         0,
       );
       countImportant += spaceAndChatCount;


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number)

#### Description of Change

`Element.getInnerHTML()` was removed in Chromium 126, so reading the chat/space badges (`div.Xa.bSyoAf span.XU`) in the Gmail recipe throws `TypeError: e.getInnerHTML is not a function`. The exception aborts `getMessages()` before `Ferdium.setBadge()` runs, so accounts with Google Chat enabled lose their unread badge entirely. Accounts without Chat never hit the code path, which made the bug look account-specific.

Fix: read the badge count with `textContent` instead. Verified in Ferdium against a Chat-enabled Gmail account (badge broken before, working after). Recipe version bumped to 1.6.4 and `pnpm lint:fix && pnpm reformat-files && pnpm package` passes (437 recipes, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)