### PR TITLE
fix: whatsapp calls not working (enable web security)

### DIFF
--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,12 +1,11 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",
     "hasNotificationSound": true,
-    "hasIndirectMessages": true,
-    "disablewebsecurity": true
+    "hasIndirectMessages": true
   }
 }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number) 

#### Description of Change

Fix WhatsApp Web voice/video calling support by removing `disablewebsecurity: true` from the WhatsApp recipe.

WhatsApp Web now relies on cross-origin isolation for its calling functionality. With `disablewebsecurity` enabled in Ferdium, the WhatsApp webview does not become cross-origin isolated:

```text
crossOriginIsolated: false
SharedArrayBuffer: undefined
```

As a result, WhatsApp reports that the browser does not support calls (in Portuguese, sorry):

> O seu navegador não suporta chamadas. Atualize o navegador ou experimente outro.

Removing `disablewebsecurity` restores the expected browser environment:

```text
crossOriginIsolated: true
SharedArrayBuffer: function
```

and WhatsApp Web calling is recognized as supported.

This change restores the default Electron web security behavior for the WhatsApp service instead of unnecessarily disabling it.

Fixes ferdium/ferdium-app#2399, https://github.com/ferdium/ferdium-app/issues/2492