### PR TITLE
Fix Instagram high CPU usage on direct messages page

### DIFF
--- a/recipes/instagram-direct-messages/package.json
+++ b/recipes/instagram-direct-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram-direct-messages",
   "name": "Instagram Direct Messages",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.instagram.com/direct/inbox/",

--- a/recipes/instagram-direct-messages/service.css
+++ b/recipes/instagram-direct-messages/service.css
@@ -11,3 +11,13 @@
 #react-root>section .i0EQd {
     max-width: unset !important;
 }
+
+/* Instagram's DM loading-skeleton shimmer animates height/transform on SVG
+   <rect>s, forcing layout+paint every vsync indefinitely (huge CPU/GPU usage,
+   especially on high-refresh displays). The skeletons are decorative
+   placeholders, so freezing them has no functional impact. Targeting all svg
+   rects (rather than Instagram's compiled class names) keeps the rule working
+   across Instagram deploys. */
+svg rect {
+  animation: none !important;
+}

--- a/recipes/instagram/package.json
+++ b/recipes/instagram/package.json
@@ -1,7 +1,7 @@
 {
   "id": "instagram",
   "name": "Instagram",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "license": "MIT",
   "config": {
     "serviceURL": "https://instagram.com/",

--- a/recipes/instagram/service.css
+++ b/recipes/instagram/service.css
@@ -9,3 +9,13 @@
 ._lz6s {
   border-bottom: 0 !important;
 }
+
+/* Instagram's DM loading-skeleton shimmer animates height/transform on SVG
+   <rect>s, forcing layout+paint every vsync indefinitely (huge CPU/GPU usage,
+   especially on high-refresh displays). The skeletons are decorative
+   placeholders, so freezing them has no functional impact. Targeting all svg
+   rects (rather than Instagram's compiled class names) keeps the rule working
+   across Instagram deploys. */
+svg rect {
+  animation: none !important;
+}


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number)

#### Description of Change

**Problem**

The Instagram service consumes excessive CPU (renderer + GPU process) whenever the direct messages page (`/direct/...`) is open, even when completely idle. On high-refresh displays the effect is amplified. Likely the cause of ferdium/ferdium-app#1663.

**Root cause**

A DevTools performance trace of the live service showed the renderer main thread running a full `style -> layout -> paint -> composite` cycle **~168 times per second, indefinitely**, with the exact same 43 objects dirtied on every layout (10.7s trace: 1798 layouts, 3596 paints, 26,970 layer updates). JS was nearly idle, ruling out timers/rAF loops and service workers.

`document.getAnimations()` identified the culprit: Instagram's loading-skeleton shimmer runs infinite CSS animations on SVG `<rect>` elements that animate **`height`** and `transform`. Since `height` is a layout property, the animation cannot be composited and forces the full render pipeline on the main thread at the display's refresh rate. This never stops, because the skeleton animations keep running after the real content loads.

**Fix**

Freeze the shimmer via the recipe's injected `service.css`:

```css
svg rect {
  animation: none !important;
}
```

The skeletons are purely decorative placeholders, so this has no functional impact. The broad `svg rect` selector is used instead of Instagram's compiled StyleX class names (e.g. `.x1c74tu6`) so the rule survives Instagram deploys. Animated rects are in practice only used for skeleton shimmers, while functional motion UI (spinners, progress rings) uses `circle`/`path`/divs and is unaffected.

**Verification**

- Before: `document.getAnimations()` on the DM page shows 3 running `CSSAnimation`s on `<rect>`s animating `transform,height`; process manager shows sustained CPU on the Instagram tab and GPU process (~1100 idle wakeups/s).
- After: running animations drop to 0, layout/paint churn stops, and CPU usage on both the Instagram tab and the GPU process returns to normal.
