### PR TITLE
add(bluesky): Implement unread badge for notifications and chat

### DIFF
--- a/recipes/bluesky/package.json
+++ b/recipes/bluesky/package.json
@@ -1,7 +1,7 @@
 {
   "id": "bluesky",
   "name": "Bluesky",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://bsky.app/"

--- a/recipes/bluesky/webview.js
+++ b/recipes/bluesky/webview.js
@@ -5,5 +5,77 @@ function _interopRequireDefault(obj) {
 const _path = _interopRequireDefault(require('path'));
 
 module.exports = Ferdium => {
+  const getMessages = () => {
+    let direct = 0;
+
+    try {
+      // Bluesky uses LeftNav (desktop) and BottomBar (mobile/web) with same hrefs.
+      // Notification count is rendered as a Text with aria-label like "3 unread items"
+      // inside a[href="/notifications"]. Same for chat: a[href="/messages"].
+      // This mirrors the Twitter recipe pattern: sum notifications + DMs.
+      const selectors = [
+        // Desktop LeftNav + Mobile BottomBar — notifications
+        'a[href^="/notifications"] [aria-label*="unread"]',
+        // Chat / messages
+        'a[href^="/messages"] [aria-label*="unread"]',
+      ];
+
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el) {
+          // textContent is the count like "3" or "30+", aria-label also contains it
+          const txt = (
+            el.textContent ||
+            el.getAttribute('aria-label') ||
+            ''
+          ).trim();
+          const m = txt.match(/(\d+)/);
+          if (m) direct += Ferdium.safeParseInt(m[1]);
+        }
+      }
+
+      // Fallback: numeric pill inside the link (when aria-label not present)
+      if (direct === 0) {
+        for (const href of ['/notifications', '/messages']) {
+          const link = document.querySelector(`a[href^="${href}"]`);
+          if (!link) continue;
+          // badge is small pill with 1-3 digit text; filter out post counts etc.
+          const candidates = link.querySelectorAll('div');
+          for (const c of candidates) {
+            const t = (c.textContent || '').trim();
+            if (
+              /^\d+\+?$/.test(t) &&
+              t.length <= 3 &&
+              c.children.length === 0
+            ) {
+              direct += Ferdium.safeParseInt(t);
+              break; // one badge per link
+            }
+          }
+        }
+      }
+
+      // hasNew dot (8px blue dot) for messages when no count — count as indirect (1)
+      if (direct === 0) {
+        const hasNewDot = document.querySelector(
+          'a[href^="/messages"] div[style*="width: 8px"]',
+        );
+        if (hasNewDot) direct = 1;
+      }
+
+      // Title fallback: bskyTitle prefixes "(3) " when unread — src/lib/strings/headings.ts
+      if (direct === 0) {
+        const m = document.title.match(/^\((\d+)\+?\)/);
+        if (m) direct = Ferdium.safeParseInt(m[1]);
+      }
+    } catch (error) {
+      console.error('Bluesky getMessages error:', error);
+    }
+
+    Ferdium.setBadge(direct);
+  };
+
+  Ferdium.loop(getMessages);
+
   Ferdium.injectCSS(_path.default.join(__dirname, 'service.css'));
 };


### PR DESCRIPTION
#### Pre-flight Checklist

Please ensure you've completed all of the following.

- [x] I have read the [Contributing Guidelines](https://github.com/ferdium/ferdium-app/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/ferdium/ferdium-app/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I updated the version package [Updating](https://github.com/ferdium/ferdium-recipes/blob/main/docs/updating.md#4-updating-the-version-number)

#### Description of Change

Bluesky recipe had no `Ferdium.setBadge` logic, so notifications/chat never produced a sidebar badge - unlike the Twitter recipe which sums `AppTabBar_Notifications_Link` + `AppTabBar_DirectMessage_Link`.

Fix: mirror Twitter pattern for Bluesky's `LeftNav`/`BottomBarWeb` (`src/view/shell/desktop/LeftNav.tsx` and `src/state/queries/notifications/unread.tsx`). Sum `a[href^="/notifications"] [aria-label*="unread"]` and `a[href^="/messages"] [aria-label*="unread"]` with numeric pill and title `(N)` fallbacks (`src/lib/strings/headings.ts:bskyTitle`). 

Bumped to 1.1.5 and `pnpm lint:fix && pnpm reformat-files && pnpm package` passes (438 recipes, 0 failures).
